### PR TITLE
Allow per team approval checks (reviewTeams)

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -623,10 +623,14 @@ async function getTeamReviewContext(config, effectiveReviews, context, pullReque
         // assign the one with priority -> the one which has been added to YML before
         if (newIndex < existingIndex) {
           teamsByUserName[login] = name;
+
+          context.log.debug(`${login} has multiple teams. Will be counted for ${name} team.`);
         }
       } else {
 
         teamsByUserName[login] = name;
+
+        context.log.debug(`${login} is a part of ${name} team.`);
       }
     });
   }

--- a/lib/core.js
+++ b/lib/core.js
@@ -143,7 +143,8 @@ async function getReviewApproval(context, pullRequest) {
   } = pullRequest;
 
   const config = await context.config('merge-me.yml', {
-    minApprovals: DEFAULT_MIN_APPROVALS
+    minApprovals: DEFAULT_MIN_APPROVALS,
+    reviewTeams: []
   });
 
   const minApprovals = Math.max(
@@ -164,6 +165,25 @@ async function getReviewApproval(context, pullRequest) {
 
   const allApproved = effectiveReviews.filter(review => review.state === APPROVED);
   const allRejected = effectiveReviews.filter(review => review.state === CHANGES_REQUESTED);
+
+  const teamReviewContext = await getTeamReviewContext(config, effectiveReviews, context, pullRequest);
+
+  if (teamReviewContext !== null) {
+
+    const { reviewRequestsByTeams, teamsByUserName } = teamReviewContext;
+
+    const { reviewTeams } = config;
+
+    if (isTeamReviewsActive(reviewRequestsByTeams, reviewTeams)) {
+
+      context.log.info('Team reviews are active.');
+
+      return getTeamReviewApproval(allApproved, allRejected, reviewTeams, teamsByUserName, minApprovals);
+    } else {
+
+      context.log.info('Team reviews are not active.');
+    }
+  }
 
   if (allApproved.length < minApprovals) {
     context.log.debug(`skipping: #${number} lacks minApprovals=${minApprovals}`);
@@ -503,6 +523,176 @@ function isCrossOriginPullRequest(pullRequest) {
   return head.repo.fullName !== base.repo.fullName;
 }
 
+function getOrgName(context, pullRequest) {
+
+  try {
+
+    const { head } = pullRequest;
+    const { repo } = head;
+    const { owner } = repo;
+
+    const { type, login } = owner;
+
+    if (type === 'Organization') {
+      return login;
+    }
+
+  } catch (err) {
+
+    context.log.error('Error happened while getting organization name.', err);
+  }
+
+  return null;
+}
+
+async function getTeamReviewContext(config, effectiveReviews, context, pullRequest) {
+
+  const { requested_reviewers } = pullRequest;
+
+  let totalRequestedReviewers = [];
+
+  // when a user approves or rejects, Github no longer considers it as a requested_reviewer
+  if (effectiveReviews) {
+    effectiveReviews.forEach(function(review) {
+      totalRequestedReviewers.push(review.user);
+    });
+  }
+
+  if (requested_reviewers) {
+    totalRequestedReviewers = totalRequestedReviewers.concat(requested_reviewers);
+  }
+
+  if (totalRequestedReviewers.length === 0) {
+
+    // No reviewers assigned
+    return null;
+  }
+
+  const orgName = getOrgName(context, pullRequest);
+
+  if (orgName === null) {
+
+    // Organization name not found.
+    return null;
+  }
+
+  const { reviewTeams } = config;
+
+  if (reviewTeams.length === 0) {
+
+    // reviewTeams not configured
+    return null;
+  }
+
+  const teamsByUserName = {};
+
+  // get team IDs
+  let response = await GithubApi(context).teams.list({ org: orgName });
+
+  // filter out unconfigured teams
+  const teams = response.data.filter(function(team) {
+    return reviewTeams.indexOf(team.name) >= 0;
+  });
+
+  for (let i = 0; i < teams.length; i ++) {
+    const team = teams[i];
+
+    const { id, name } = team;
+
+    // get members of given team
+    response = await GithubApi(context).teams.listMembers({
+      org: orgName,
+      team_id: id
+    });
+
+    const members = response.data;
+
+    // fill teamsByUserName map
+    members.forEach(function(member) {
+
+      const { login } = member;
+
+      const existingTeamName = teamsByUserName[login];
+
+      if (existingTeamName !== undefined) {
+
+        const existingIndex = reviewTeams.indexOf(existingTeamName);
+        const newIndex = reviewTeams.indexOf(name);
+
+        // user has multiple teams
+        // assign the one with priority -> the one which has been added to YML before
+        if (newIndex < existingIndex) {
+          teamsByUserName[login] = name;
+        }
+      } else {
+
+        teamsByUserName[login] = name;
+      }
+    });
+  }
+
+  // find the teams associated by reviewers
+  const reviewRequestsByTeams = {};
+  totalRequestedReviewers.forEach(function(user) {
+
+    const { login } = user;
+    const userTeam = teamsByUserName[login];
+
+    if (userTeam !== undefined) {
+      reviewRequestsByTeams[userTeam] = true;
+    }
+  });
+
+  return { reviewRequestsByTeams, teamsByUserName };
+}
+
+function isTeamReviewsActive(reviewRequestsByTeams, reviewTeams) {
+
+  // return if at least one person from each configured team is assigned for a review
+  return Object.keys(reviewRequestsByTeams).length === reviewTeams.length;
+}
+
+function getTeamReviewApproval(allApproved, allRejected, reviewTeams, teamsByUserName, minApprovals) {
+
+  if (allRejected.length > 0) {
+
+    // early return if there are requested changes
+    return CHANGES_REQUESTED;
+  }
+
+  const totalApprovalsByTeams = {};
+
+  // initialize map
+  reviewTeams.forEach(function(team) {
+
+    totalApprovalsByTeams[team] = 0;
+  });
+
+  // calculate how many approvals exist per team
+  allApproved.forEach(function(approval) {
+
+    const userName = approval.user.login;
+    const team = teamsByUserName[userName];
+
+    if (team !== undefined) {
+
+      totalApprovalsByTeams[team] ++;
+    }
+  });
+
+  // PR is approved only if at least [minApprovals] of approvals are given by each team
+  for (let team in totalApprovalsByTeams) {
+
+    const totalApproval = totalApprovalsByTeams[team];
+
+    if (totalApproval < minApprovals) {
+
+      return REVIEWS_MISSING;
+    }
+  }
+
+  return APPROVED;
+}
 
 // module exports //////////////////////////////
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -151,7 +151,7 @@ async function getReviewApproval(context, pullRequest) {
     config.minApprovals
   );
 
-  context.log.debug(`checking if #${number} is approved via reviews`);
+  context.log.debug(`checking if #${number} is approved via reviews. minApprovals: ${minApprovals}`);
 
   // https://octokit.github.io/rest.js/#api-PullRequests-listReviews
   const {

--- a/lib/core.js
+++ b/lib/core.js
@@ -176,12 +176,12 @@ async function getReviewApproval(context, pullRequest) {
 
     if (isTeamReviewsActive(reviewRequestsByTeams, reviewTeams)) {
 
-      context.log.info('Team reviews are active.');
+      context.log.debug('Team reviews are active.');
 
       return getTeamReviewApproval(allApproved, allRejected, reviewTeams, teamsByUserName, minApprovals);
     } else {
 
-      context.log.info('Team reviews are not active.');
+      context.log.debug('Team reviews are not active.');
     }
   }
 

--- a/test/fixtures/review_teams_approval_missing/028_check_suite.completed.json
+++ b/test/fixtures/review_teams_approval_missing/028_check_suite.completed.json
@@ -1,0 +1,94 @@
+{
+  "name": "check_suite.completed",
+  "type": "event",
+  "payload": {
+    "action": "completed",
+    "check_suite": {
+      "head_branch": "test-test",
+      "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "status": "completed",
+      "conclusion": "success",
+      "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+      "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "pull_requests": [
+        {
+          "number": 12,
+          "head": {
+            "ref": "test-test",
+            "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+            "repo": {
+              "name": "merge-me-test"
+            }
+          },
+          "base": {
+            "ref": "master",
+            "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+            "repo": {
+              "name": "merge-me-test"
+            }
+          }
+        }
+      ],
+      "app": {
+        "slug": "travis-ci",
+        "owner": {
+          "login": "travis-ci",
+          "type": "Organization"
+        },
+        "name": "Travis CI",
+        "permissions": {
+          "checks": "write",
+          "contents": "read",
+          "deployments": "write",
+          "members": "read",
+          "metadata": "read",
+          "pull_requests": "read",
+          "repository_hooks": "write",
+          "statuses": "write"
+        },
+        "events": [
+          "check_run",
+          "check_suite",
+          "create",
+          "delete",
+          "member",
+          "pull_request",
+          "push",
+          "repository"
+        ]
+      },
+      "latest_check_runs_count": 2,
+      "head_commit": {
+        "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+        "message": "feat: test2",
+        "timestamp": "2020-05-28T08:47:11Z",
+        "author": {
+          "name": "Oguz"
+        },
+        "committer": {
+          "name": "Oguz"
+        }
+      }
+    },
+    "repository": {
+      "name": "merge-me-test",
+      "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+      "owner": {
+        "login": "Merge-Me-Test-Organisation",
+        "type": "Organization"
+      },
+      "size": 16,
+      "stargazers_count": 0,
+      "watchers_count": 0,
+      "forks_count": 0,
+      "open_issues_count": 1,
+      "forks": 0,
+      "open_issues": 1,
+      "watchers": 0,
+      "default_branch": "master"
+    },
+    "organization": {
+      "login": "Merge-Me-Test-Organisation"
+    }
+  }
+}

--- a/test/fixtures/review_teams_approval_missing/030_repos.getBranchProtection.json
+++ b/test/fixtures/review_teams_approval_missing/030_repos.getBranchProtection.json
@@ -1,0 +1,59 @@
+{
+  "name": "repos.getBranchProtection",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "branch": "master"
+  },
+  "result": {
+    "error": {
+      "name": "HttpError",
+      "status": 404,
+      "headers": {
+        "access-control-allow-origin": "*",
+        "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset",
+        "connection": "close",
+        "content-encoding": "gzip",
+        "content-security-policy": "default-src 'none'",
+        "content-type": "application/json; charset=utf-8",
+        "referrer-policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+        "server": "GitHub.com",
+        "status": "404 Not Found",
+        "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
+        "transfer-encoding": "chunked",
+        "vary": "Accept-Encoding, Accept, X-Requested-With",
+        "x-content-type-options": "nosniff",
+        "x-frame-options": "deny",
+        "x-github-media-type": "github.v3; format=json",
+        "x-github-request-id": "49A9:2616C:16C612F:1A8A370:5ECF7AE7",
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-remaining": "4949",
+        "x-ratelimit-reset": "1590657537",
+        "x-xss-protection": "1; mode=block"
+      },
+      "request": {
+        "method": "GET",
+        "headers": {
+          "accept": "application/vnd.github.v3+json",
+          "user-agent": "octokit.js/16.20.0 Node.js/12.9.1 (macOS Mojave; x64)",
+          "authorization": "token [REDACTED]"
+        },
+        "request": {
+          "validate": {
+            "branch": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "repo": {
+              "type": "string"
+            }
+          },
+          "retryCount": 1
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/review_teams_approval_missing/031_repos.getCombinedStatusForRef.json
+++ b/test/fixtures/review_teams_approval_missing/031_repos.getCombinedStatusForRef.json
@@ -1,0 +1,25 @@
+{
+  "name": "repos.getCombinedStatusForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "ref": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+  },
+  "result": {
+    "data": {
+      "state": "pending",
+      "statuses": [],
+      "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "total_count": 0,
+      "repository": {
+        "name": "merge-me-test",
+        "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+        "owner": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/review_teams_approval_missing/032_checks.listSuitesForRef.json
+++ b/test/fixtures/review_teams_approval_missing/032_checks.listSuitesForRef.json
@@ -1,0 +1,255 @@
+{
+  "name": "checks.listSuitesForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "ref": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+  },
+  "result": {
+    "data": {
+      "total_count": 3,
+      "check_suites": [
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "queued",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [
+            {
+              "number": 12,
+              "head": {
+                "ref": "test-test",
+                "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+                "repo": {
+                  "name": "merge-me-test"
+                }
+              },
+              "base": {
+                "ref": "master",
+                "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+                "repo": {
+                  "name": "merge-me-test"
+                }
+              }
+            }
+          ],
+          "app": {
+            "slug": "merge-me-test-app2",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            },
+            "name": "merge-me-test-app2",
+            "permissions": {
+              "actions": "write",
+              "administration": "write",
+              "blocking": "write",
+              "checks": "write",
+              "contents": "write",
+              "deployments": "write",
+              "emails": "write",
+              "followers": "write",
+              "gpg_keys": "write",
+              "issues": "write",
+              "keys": "write",
+              "members": "write",
+              "metadata": "read",
+              "organization_administration": "write",
+              "organization_hooks": "write",
+              "organization_plan": "read",
+              "organization_projects": "admin",
+              "organization_secrets": "write",
+              "organization_self_hosted_runners": "write",
+              "organization_user_blocking": "write",
+              "pages": "write",
+              "plan": "read",
+              "pull_requests": "write",
+              "repository_hooks": "write",
+              "repository_projects": "admin",
+              "secrets": "write",
+              "security_events": "write",
+              "starring": "write",
+              "statuses": "write",
+              "team_discussions": "write",
+              "vulnerability_alerts": "read",
+              "watching": "write",
+              "workflows": "write"
+            },
+            "events": [
+              "check_run",
+              "check_suite",
+              "commit_comment",
+              "create",
+              "delete",
+              "deployment",
+              "deployment_status",
+              "deploy_key",
+              "fork",
+              "gollum",
+              "issues",
+              "issue_comment",
+              "label",
+              "member",
+              "membership",
+              "milestone",
+              "organization",
+              "org_block",
+              "page_build",
+              "project",
+              "project_card",
+              "project_column",
+              "public",
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment",
+              "push",
+              "release",
+              "repository",
+              "repository_dispatch",
+              "star",
+              "status",
+              "team",
+              "team_add",
+              "watch"
+            ]
+          },
+          "latest_check_runs_count": 0,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        },
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "completed",
+          "conclusion": "success",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [],
+          "app": {
+            "slug": "travis-ci",
+            "owner": {
+              "login": "travis-ci",
+              "type": "Organization"
+            },
+            "name": "Travis CI",
+            "permissions": {
+              "checks": "write",
+              "contents": "read",
+              "deployments": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "read",
+              "repository_hooks": "write",
+              "statuses": "write"
+            },
+            "events": [
+              "check_run",
+              "check_suite",
+              "create",
+              "delete",
+              "member",
+              "pull_request",
+              "push",
+              "repository"
+            ]
+          },
+          "latest_check_runs_count": 2,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        },
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "queued",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [],
+          "app": {
+            "slug": "dependabot",
+            "owner": {
+              "login": "github",
+              "type": "Organization"
+            },
+            "name": "Dependabot",
+            "permissions": {
+              "checks": "write",
+              "contents": "write",
+              "issues": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "write",
+              "statuses": "read",
+              "workflows": "write"
+            },
+            "events": [
+              "check_suite",
+              "issues",
+              "issue_comment",
+              "label",
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment",
+              "repository"
+            ]
+          },
+          "latest_check_runs_count": 0,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/review_teams_approval_missing/033_repos.getContents.json
+++ b/test/fixtures/review_teams_approval_missing/033_repos.getContents.json
@@ -1,0 +1,20 @@
+{
+  "name": "repos.getContents",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "path": ".github/merge-me.yml"
+  },
+  "result": {
+    "data": {
+      "name": "merge-me.yml",
+      "path": ".github/merge-me.yml",
+      "sha": "4c061e4bc0fff3dd9ffce937c320fdead239b564",
+      "size": 28,
+      "type": "file",
+      "content": "cmV2aWV3VGVhbXM6Ci0gZGV2Ci0gZGVzaWduCg==\n",
+      "encoding": "base64"
+    }
+  }
+}

--- a/test/fixtures/review_teams_approval_missing/034_pullRequests.listReviews.json
+++ b/test/fixtures/review_teams_approval_missing/034_pullRequests.listReviews.json
@@ -1,0 +1,12 @@
+{
+  "name": "pullRequests.listReviews",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "number": 12
+  },
+  "result": {
+    "data": []
+  }
+}

--- a/test/fixtures/review_teams_approval_missing/035_pull_request_review.submitted.json
+++ b/test/fixtures/review_teams_approval_missing/035_pull_request_review.submitted.json
@@ -1,0 +1,109 @@
+{
+  "name": "pull_request_review.submitted",
+  "type": "event",
+  "payload": {
+    "action": "submitted",
+    "review": {
+      "user": {
+        "login": "notoguz",
+        "type": "User"
+      },
+      "commit_id": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "state": "approved",
+      "author_association": "NONE"
+    },
+    "pull_request": {
+      "number": 12,
+      "state": "open",
+      "title": "feat: test",
+      "user": {
+        "login": "oguzeroglu",
+        "type": "User"
+      },
+      "merge_commit_sha": "fb6bd8d36aaa8bd88d51feee985ed6d10e311520",
+      "assignees": [],
+      "requested_reviewers": [
+        {
+          "login": "notoguz",
+          "type": "User"
+        }
+      ],
+      "requested_teams": [],
+      "labels": [],
+      "draft": false,
+      "head": {
+        "label": "Merge-Me-Test-Organisation:test-test",
+        "ref": "test-test",
+        "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+        "user": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        },
+        "repo": {
+          "name": "merge-me-test",
+          "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+          "owner": {
+            "login": "Merge-Me-Test-Organisation",
+            "type": "Organization"
+          },
+          "size": 16,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 1,
+          "forks": 0,
+          "open_issues": 1,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "base": {
+        "label": "Merge-Me-Test-Organisation:master",
+        "ref": "master",
+        "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+        "user": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        },
+        "repo": {
+          "name": "merge-me-test",
+          "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+          "owner": {
+            "login": "Merge-Me-Test-Organisation",
+            "type": "Organization"
+          },
+          "size": 16,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 1,
+          "forks": 0,
+          "open_issues": 1,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "author_association": "MEMBER"
+    },
+    "repository": {
+      "name": "merge-me-test",
+      "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+      "owner": {
+        "login": "Merge-Me-Test-Organisation",
+        "type": "Organization"
+      },
+      "size": 16,
+      "stargazers_count": 0,
+      "watchers_count": 0,
+      "forks_count": 0,
+      "open_issues_count": 1,
+      "forks": 0,
+      "open_issues": 1,
+      "watchers": 0,
+      "default_branch": "master"
+    },
+    "organization": {
+      "login": "Merge-Me-Test-Organisation"
+    }
+  }
+}

--- a/test/fixtures/review_teams_approval_missing/036_repos.getBranchProtection.json
+++ b/test/fixtures/review_teams_approval_missing/036_repos.getBranchProtection.json
@@ -1,0 +1,59 @@
+{
+  "name": "repos.getBranchProtection",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "branch": "master"
+  },
+  "result": {
+    "error": {
+      "name": "HttpError",
+      "status": 404,
+      "headers": {
+        "access-control-allow-origin": "*",
+        "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset",
+        "connection": "close",
+        "content-encoding": "gzip",
+        "content-security-policy": "default-src 'none'",
+        "content-type": "application/json; charset=utf-8",
+        "referrer-policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+        "server": "GitHub.com",
+        "status": "404 Not Found",
+        "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
+        "transfer-encoding": "chunked",
+        "vary": "Accept-Encoding, Accept, X-Requested-With",
+        "x-content-type-options": "nosniff",
+        "x-frame-options": "deny",
+        "x-github-media-type": "github.v3; format=json",
+        "x-github-request-id": "490E:81D5:5370D6:609E5B:5ECF7B06",
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-remaining": "4944",
+        "x-ratelimit-reset": "1590657536",
+        "x-xss-protection": "1; mode=block"
+      },
+      "request": {
+        "method": "GET",
+        "headers": {
+          "accept": "application/vnd.github.v3+json",
+          "user-agent": "octokit.js/16.20.0 Node.js/12.9.1 (macOS Mojave; x64)",
+          "authorization": "token [REDACTED]"
+        },
+        "request": {
+          "validate": {
+            "branch": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "repo": {
+              "type": "string"
+            }
+          },
+          "retryCount": 1
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/review_teams_approval_missing/037_repos.getCombinedStatusForRef.json
+++ b/test/fixtures/review_teams_approval_missing/037_repos.getCombinedStatusForRef.json
@@ -1,0 +1,25 @@
+{
+  "name": "repos.getCombinedStatusForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "ref": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+  },
+  "result": {
+    "data": {
+      "state": "pending",
+      "statuses": [],
+      "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "total_count": 0,
+      "repository": {
+        "name": "merge-me-test",
+        "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+        "owner": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/review_teams_approval_missing/038_checks.listSuitesForRef.json
+++ b/test/fixtures/review_teams_approval_missing/038_checks.listSuitesForRef.json
@@ -1,0 +1,255 @@
+{
+  "name": "checks.listSuitesForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "ref": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+  },
+  "result": {
+    "data": {
+      "total_count": 3,
+      "check_suites": [
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "queued",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [
+            {
+              "number": 12,
+              "head": {
+                "ref": "test-test",
+                "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+                "repo": {
+                  "name": "merge-me-test"
+                }
+              },
+              "base": {
+                "ref": "master",
+                "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+                "repo": {
+                  "name": "merge-me-test"
+                }
+              }
+            }
+          ],
+          "app": {
+            "slug": "merge-me-test-app2",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            },
+            "name": "merge-me-test-app2",
+            "permissions": {
+              "actions": "write",
+              "administration": "write",
+              "blocking": "write",
+              "checks": "write",
+              "contents": "write",
+              "deployments": "write",
+              "emails": "write",
+              "followers": "write",
+              "gpg_keys": "write",
+              "issues": "write",
+              "keys": "write",
+              "members": "write",
+              "metadata": "read",
+              "organization_administration": "write",
+              "organization_hooks": "write",
+              "organization_plan": "read",
+              "organization_projects": "admin",
+              "organization_secrets": "write",
+              "organization_self_hosted_runners": "write",
+              "organization_user_blocking": "write",
+              "pages": "write",
+              "plan": "read",
+              "pull_requests": "write",
+              "repository_hooks": "write",
+              "repository_projects": "admin",
+              "secrets": "write",
+              "security_events": "write",
+              "starring": "write",
+              "statuses": "write",
+              "team_discussions": "write",
+              "vulnerability_alerts": "read",
+              "watching": "write",
+              "workflows": "write"
+            },
+            "events": [
+              "check_run",
+              "check_suite",
+              "commit_comment",
+              "create",
+              "delete",
+              "deployment",
+              "deployment_status",
+              "deploy_key",
+              "fork",
+              "gollum",
+              "issues",
+              "issue_comment",
+              "label",
+              "member",
+              "membership",
+              "milestone",
+              "organization",
+              "org_block",
+              "page_build",
+              "project",
+              "project_card",
+              "project_column",
+              "public",
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment",
+              "push",
+              "release",
+              "repository",
+              "repository_dispatch",
+              "star",
+              "status",
+              "team",
+              "team_add",
+              "watch"
+            ]
+          },
+          "latest_check_runs_count": 0,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        },
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "completed",
+          "conclusion": "success",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [],
+          "app": {
+            "slug": "travis-ci",
+            "owner": {
+              "login": "travis-ci",
+              "type": "Organization"
+            },
+            "name": "Travis CI",
+            "permissions": {
+              "checks": "write",
+              "contents": "read",
+              "deployments": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "read",
+              "repository_hooks": "write",
+              "statuses": "write"
+            },
+            "events": [
+              "check_run",
+              "check_suite",
+              "create",
+              "delete",
+              "member",
+              "pull_request",
+              "push",
+              "repository"
+            ]
+          },
+          "latest_check_runs_count": 2,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        },
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "queued",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [],
+          "app": {
+            "slug": "dependabot",
+            "owner": {
+              "login": "github",
+              "type": "Organization"
+            },
+            "name": "Dependabot",
+            "permissions": {
+              "checks": "write",
+              "contents": "write",
+              "issues": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "write",
+              "statuses": "read",
+              "workflows": "write"
+            },
+            "events": [
+              "check_suite",
+              "issues",
+              "issue_comment",
+              "label",
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment",
+              "repository"
+            ]
+          },
+          "latest_check_runs_count": 0,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/review_teams_approval_missing/039_repos.getContents.json
+++ b/test/fixtures/review_teams_approval_missing/039_repos.getContents.json
@@ -1,0 +1,20 @@
+{
+  "name": "repos.getContents",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "path": ".github/merge-me.yml"
+  },
+  "result": {
+    "data": {
+      "name": "merge-me.yml",
+      "path": ".github/merge-me.yml",
+      "sha": "4c061e4bc0fff3dd9ffce937c320fdead239b564",
+      "size": 28,
+      "type": "file",
+      "content": "cmV2aWV3VGVhbXM6Ci0gZGV2Ci0gZGVzaWduCg==\n",
+      "encoding": "base64"
+    }
+  }
+}

--- a/test/fixtures/review_teams_approval_missing/040_pullRequests.listReviews.json
+++ b/test/fixtures/review_teams_approval_missing/040_pullRequests.listReviews.json
@@ -1,0 +1,40 @@
+{
+  "name": "pullRequests.listReviews",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "number": 12
+  },
+  "result": {
+    "data": [
+      {
+        "user": {
+          "login": "notoguz",
+          "type": "User"
+        },
+        "state": "APPROVED",
+        "author_association": "MEMBER",
+        "commit_id": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+      },
+      {
+        "user": {
+          "login": "notoguz2",
+          "type": "User"
+        },
+        "state": "PENDING",
+        "author_association": "MEMBER",
+        "commit_id": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+      },
+      {
+        "user": {
+          "login": "notoguz3",
+          "type": "User"
+        },
+        "state": "APPROVED",
+        "author_association": "MEMBER",
+        "commit_id": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+      }
+    ]
+  }
+}

--- a/test/fixtures/review_teams_approval_missing/041_teams.list.json
+++ b/test/fixtures/review_teams_approval_missing/041_teams.list.json
@@ -1,0 +1,31 @@
+{
+  "name": "teams.list",
+  "type": "api-call",
+  "args": {
+    "org": "Merge-Me-Test-Organisation"
+  },
+  "result": {
+    "data": [
+      {
+        "name": "design",
+        "id": 3861523,
+        "slug": "design",
+        "privacy": "closed",
+        "permission": "pull"
+      },
+      {
+        "name": "dev",
+        "id": 3861522,
+        "slug": "dev",
+        "privacy": "closed",
+        "permission": "pull"
+      },
+      {
+        "name": "testteam123",
+        "slug": "testteam123",
+        "privacy": "closed",
+        "permission": "pull"
+      }
+    ]
+  }
+}

--- a/test/fixtures/review_teams_approval_missing/042_teams.listMembers.json
+++ b/test/fixtures/review_teams_approval_missing/042_teams.listMembers.json
@@ -1,0 +1,20 @@
+{
+  "name": "teams.listMembers",
+  "type": "api-call",
+  "args": {
+    "org": "Merge-Me-Test-Organisation",
+    "team_id": 3861523
+  },
+  "result": {
+    "data": [
+      {
+        "login": "oguzeroglu",
+        "type": "User"
+      },
+      {
+        "login": "notoguz2",
+        "type": "User"
+      }
+    ]
+  }
+}

--- a/test/fixtures/review_teams_approval_missing/043_teams.listMembers.json
+++ b/test/fixtures/review_teams_approval_missing/043_teams.listMembers.json
@@ -1,0 +1,24 @@
+{
+  "name": "teams.listMembers",
+  "type": "api-call",
+  "args": {
+    "org": "Merge-Me-Test-Organisation",
+    "team_id": 3861522
+  },
+  "result": {
+    "data": [
+      {
+        "login": "oguzeroglu",
+        "type": "User"
+      },
+      {
+        "login": "notoguz",
+        "type": "User"
+      },
+      {
+        "login": "notoguz3",
+        "type": "User"
+      }
+    ]
+  }
+}

--- a/test/fixtures/review_teams_multi_team/028_check_suite.completed.json
+++ b/test/fixtures/review_teams_multi_team/028_check_suite.completed.json
@@ -1,0 +1,94 @@
+{
+  "name": "check_suite.completed",
+  "type": "event",
+  "payload": {
+    "action": "completed",
+    "check_suite": {
+      "head_branch": "test-test",
+      "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "status": "completed",
+      "conclusion": "success",
+      "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+      "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "pull_requests": [
+        {
+          "number": 12,
+          "head": {
+            "ref": "test-test",
+            "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+            "repo": {
+              "name": "merge-me-test"
+            }
+          },
+          "base": {
+            "ref": "master",
+            "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+            "repo": {
+              "name": "merge-me-test"
+            }
+          }
+        }
+      ],
+      "app": {
+        "slug": "travis-ci",
+        "owner": {
+          "login": "travis-ci",
+          "type": "Organization"
+        },
+        "name": "Travis CI",
+        "permissions": {
+          "checks": "write",
+          "contents": "read",
+          "deployments": "write",
+          "members": "read",
+          "metadata": "read",
+          "pull_requests": "read",
+          "repository_hooks": "write",
+          "statuses": "write"
+        },
+        "events": [
+          "check_run",
+          "check_suite",
+          "create",
+          "delete",
+          "member",
+          "pull_request",
+          "push",
+          "repository"
+        ]
+      },
+      "latest_check_runs_count": 2,
+      "head_commit": {
+        "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+        "message": "feat: test2",
+        "timestamp": "2020-05-28T08:47:11Z",
+        "author": {
+          "name": "Oguz"
+        },
+        "committer": {
+          "name": "Oguz"
+        }
+      }
+    },
+    "repository": {
+      "name": "merge-me-test",
+      "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+      "owner": {
+        "login": "Merge-Me-Test-Organisation",
+        "type": "Organization"
+      },
+      "size": 16,
+      "stargazers_count": 0,
+      "watchers_count": 0,
+      "forks_count": 0,
+      "open_issues_count": 1,
+      "forks": 0,
+      "open_issues": 1,
+      "watchers": 0,
+      "default_branch": "master"
+    },
+    "organization": {
+      "login": "Merge-Me-Test-Organisation"
+    }
+  }
+}

--- a/test/fixtures/review_teams_multi_team/030_repos.getBranchProtection.json
+++ b/test/fixtures/review_teams_multi_team/030_repos.getBranchProtection.json
@@ -1,0 +1,59 @@
+{
+  "name": "repos.getBranchProtection",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "branch": "master"
+  },
+  "result": {
+    "error": {
+      "name": "HttpError",
+      "status": 404,
+      "headers": {
+        "access-control-allow-origin": "*",
+        "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset",
+        "connection": "close",
+        "content-encoding": "gzip",
+        "content-security-policy": "default-src 'none'",
+        "content-type": "application/json; charset=utf-8",
+        "referrer-policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+        "server": "GitHub.com",
+        "status": "404 Not Found",
+        "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
+        "transfer-encoding": "chunked",
+        "vary": "Accept-Encoding, Accept, X-Requested-With",
+        "x-content-type-options": "nosniff",
+        "x-frame-options": "deny",
+        "x-github-media-type": "github.v3; format=json",
+        "x-github-request-id": "49A9:2616C:16C612F:1A8A370:5ECF7AE7",
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-remaining": "4949",
+        "x-ratelimit-reset": "1590657537",
+        "x-xss-protection": "1; mode=block"
+      },
+      "request": {
+        "method": "GET",
+        "headers": {
+          "accept": "application/vnd.github.v3+json",
+          "user-agent": "octokit.js/16.20.0 Node.js/12.9.1 (macOS Mojave; x64)",
+          "authorization": "token [REDACTED]"
+        },
+        "request": {
+          "validate": {
+            "branch": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "repo": {
+              "type": "string"
+            }
+          },
+          "retryCount": 1
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/review_teams_multi_team/031_repos.getCombinedStatusForRef.json
+++ b/test/fixtures/review_teams_multi_team/031_repos.getCombinedStatusForRef.json
@@ -1,0 +1,25 @@
+{
+  "name": "repos.getCombinedStatusForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "ref": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+  },
+  "result": {
+    "data": {
+      "state": "pending",
+      "statuses": [],
+      "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "total_count": 0,
+      "repository": {
+        "name": "merge-me-test",
+        "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+        "owner": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/review_teams_multi_team/032_checks.listSuitesForRef.json
+++ b/test/fixtures/review_teams_multi_team/032_checks.listSuitesForRef.json
@@ -1,0 +1,255 @@
+{
+  "name": "checks.listSuitesForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "ref": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+  },
+  "result": {
+    "data": {
+      "total_count": 3,
+      "check_suites": [
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "queued",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [
+            {
+              "number": 12,
+              "head": {
+                "ref": "test-test",
+                "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+                "repo": {
+                  "name": "merge-me-test"
+                }
+              },
+              "base": {
+                "ref": "master",
+                "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+                "repo": {
+                  "name": "merge-me-test"
+                }
+              }
+            }
+          ],
+          "app": {
+            "slug": "merge-me-test-app2",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            },
+            "name": "merge-me-test-app2",
+            "permissions": {
+              "actions": "write",
+              "administration": "write",
+              "blocking": "write",
+              "checks": "write",
+              "contents": "write",
+              "deployments": "write",
+              "emails": "write",
+              "followers": "write",
+              "gpg_keys": "write",
+              "issues": "write",
+              "keys": "write",
+              "members": "write",
+              "metadata": "read",
+              "organization_administration": "write",
+              "organization_hooks": "write",
+              "organization_plan": "read",
+              "organization_projects": "admin",
+              "organization_secrets": "write",
+              "organization_self_hosted_runners": "write",
+              "organization_user_blocking": "write",
+              "pages": "write",
+              "plan": "read",
+              "pull_requests": "write",
+              "repository_hooks": "write",
+              "repository_projects": "admin",
+              "secrets": "write",
+              "security_events": "write",
+              "starring": "write",
+              "statuses": "write",
+              "team_discussions": "write",
+              "vulnerability_alerts": "read",
+              "watching": "write",
+              "workflows": "write"
+            },
+            "events": [
+              "check_run",
+              "check_suite",
+              "commit_comment",
+              "create",
+              "delete",
+              "deployment",
+              "deployment_status",
+              "deploy_key",
+              "fork",
+              "gollum",
+              "issues",
+              "issue_comment",
+              "label",
+              "member",
+              "membership",
+              "milestone",
+              "organization",
+              "org_block",
+              "page_build",
+              "project",
+              "project_card",
+              "project_column",
+              "public",
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment",
+              "push",
+              "release",
+              "repository",
+              "repository_dispatch",
+              "star",
+              "status",
+              "team",
+              "team_add",
+              "watch"
+            ]
+          },
+          "latest_check_runs_count": 0,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        },
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "completed",
+          "conclusion": "success",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [],
+          "app": {
+            "slug": "travis-ci",
+            "owner": {
+              "login": "travis-ci",
+              "type": "Organization"
+            },
+            "name": "Travis CI",
+            "permissions": {
+              "checks": "write",
+              "contents": "read",
+              "deployments": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "read",
+              "repository_hooks": "write",
+              "statuses": "write"
+            },
+            "events": [
+              "check_run",
+              "check_suite",
+              "create",
+              "delete",
+              "member",
+              "pull_request",
+              "push",
+              "repository"
+            ]
+          },
+          "latest_check_runs_count": 2,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        },
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "queued",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [],
+          "app": {
+            "slug": "dependabot",
+            "owner": {
+              "login": "github",
+              "type": "Organization"
+            },
+            "name": "Dependabot",
+            "permissions": {
+              "checks": "write",
+              "contents": "write",
+              "issues": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "write",
+              "statuses": "read",
+              "workflows": "write"
+            },
+            "events": [
+              "check_suite",
+              "issues",
+              "issue_comment",
+              "label",
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment",
+              "repository"
+            ]
+          },
+          "latest_check_runs_count": 0,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/review_teams_multi_team/033_repos.getContents.json
+++ b/test/fixtures/review_teams_multi_team/033_repos.getContents.json
@@ -1,0 +1,20 @@
+{
+  "name": "repos.getContents",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "path": ".github/merge-me.yml"
+  },
+  "result": {
+    "data": {
+      "name": "merge-me.yml",
+      "path": ".github/merge-me.yml",
+      "sha": "4c061e4bc0fff3dd9ffce937c320fdead239b564",
+      "size": 28,
+      "type": "file",
+      "content": "cmV2aWV3VGVhbXM6Ci0gZGV2Ci0gZGVzaWduCg==\n",
+      "encoding": "base64"
+    }
+  }
+}

--- a/test/fixtures/review_teams_multi_team/034_pullRequests.listReviews.json
+++ b/test/fixtures/review_teams_multi_team/034_pullRequests.listReviews.json
@@ -1,0 +1,12 @@
+{
+  "name": "pullRequests.listReviews",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "number": 12
+  },
+  "result": {
+    "data": []
+  }
+}

--- a/test/fixtures/review_teams_multi_team/035_pull_request_review.submitted.json
+++ b/test/fixtures/review_teams_multi_team/035_pull_request_review.submitted.json
@@ -1,0 +1,109 @@
+{
+  "name": "pull_request_review.submitted",
+  "type": "event",
+  "payload": {
+    "action": "submitted",
+    "review": {
+      "user": {
+        "login": "notoguz2",
+        "type": "User"
+      },
+      "commit_id": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "state": "approved",
+      "author_association": "NONE"
+    },
+    "pull_request": {
+      "number": 12,
+      "state": "open",
+      "title": "feat: test",
+      "user": {
+        "login": "oguzeroglu",
+        "type": "User"
+      },
+      "merge_commit_sha": "fb6bd8d36aaa8bd88d51feee985ed6d10e311520",
+      "assignees": [],
+      "requested_reviewers": [
+        {
+          "login": "notoguz",
+          "type": "User"
+        }
+      ],
+      "requested_teams": [],
+      "labels": [],
+      "draft": false,
+      "head": {
+        "label": "Merge-Me-Test-Organisation:test-test",
+        "ref": "test-test",
+        "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+        "user": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        },
+        "repo": {
+          "name": "merge-me-test",
+          "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+          "owner": {
+            "login": "Merge-Me-Test-Organisation",
+            "type": "Organization"
+          },
+          "size": 16,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 1,
+          "forks": 0,
+          "open_issues": 1,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "base": {
+        "label": "Merge-Me-Test-Organisation:master",
+        "ref": "master",
+        "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+        "user": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        },
+        "repo": {
+          "name": "merge-me-test",
+          "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+          "owner": {
+            "login": "Merge-Me-Test-Organisation",
+            "type": "Organization"
+          },
+          "size": 16,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 1,
+          "forks": 0,
+          "open_issues": 1,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "author_association": "MEMBER"
+    },
+    "repository": {
+      "name": "merge-me-test",
+      "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+      "owner": {
+        "login": "Merge-Me-Test-Organisation",
+        "type": "Organization"
+      },
+      "size": 16,
+      "stargazers_count": 0,
+      "watchers_count": 0,
+      "forks_count": 0,
+      "open_issues_count": 1,
+      "forks": 0,
+      "open_issues": 1,
+      "watchers": 0,
+      "default_branch": "master"
+    },
+    "organization": {
+      "login": "Merge-Me-Test-Organisation"
+    }
+  }
+}

--- a/test/fixtures/review_teams_multi_team/036_repos.getBranchProtection.json
+++ b/test/fixtures/review_teams_multi_team/036_repos.getBranchProtection.json
@@ -1,0 +1,59 @@
+{
+  "name": "repos.getBranchProtection",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "branch": "master"
+  },
+  "result": {
+    "error": {
+      "name": "HttpError",
+      "status": 404,
+      "headers": {
+        "access-control-allow-origin": "*",
+        "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset",
+        "connection": "close",
+        "content-encoding": "gzip",
+        "content-security-policy": "default-src 'none'",
+        "content-type": "application/json; charset=utf-8",
+        "referrer-policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+        "server": "GitHub.com",
+        "status": "404 Not Found",
+        "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
+        "transfer-encoding": "chunked",
+        "vary": "Accept-Encoding, Accept, X-Requested-With",
+        "x-content-type-options": "nosniff",
+        "x-frame-options": "deny",
+        "x-github-media-type": "github.v3; format=json",
+        "x-github-request-id": "490E:81D5:5370D6:609E5B:5ECF7B06",
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-remaining": "4944",
+        "x-ratelimit-reset": "1590657536",
+        "x-xss-protection": "1; mode=block"
+      },
+      "request": {
+        "method": "GET",
+        "headers": {
+          "accept": "application/vnd.github.v3+json",
+          "user-agent": "octokit.js/16.20.0 Node.js/12.9.1 (macOS Mojave; x64)",
+          "authorization": "token [REDACTED]"
+        },
+        "request": {
+          "validate": {
+            "branch": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "repo": {
+              "type": "string"
+            }
+          },
+          "retryCount": 1
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/review_teams_multi_team/037_repos.getCombinedStatusForRef.json
+++ b/test/fixtures/review_teams_multi_team/037_repos.getCombinedStatusForRef.json
@@ -1,0 +1,25 @@
+{
+  "name": "repos.getCombinedStatusForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "ref": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+  },
+  "result": {
+    "data": {
+      "state": "pending",
+      "statuses": [],
+      "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "total_count": 0,
+      "repository": {
+        "name": "merge-me-test",
+        "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+        "owner": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/review_teams_multi_team/038_checks.listSuitesForRef.json
+++ b/test/fixtures/review_teams_multi_team/038_checks.listSuitesForRef.json
@@ -1,0 +1,255 @@
+{
+  "name": "checks.listSuitesForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "ref": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+  },
+  "result": {
+    "data": {
+      "total_count": 3,
+      "check_suites": [
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "queued",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [
+            {
+              "number": 12,
+              "head": {
+                "ref": "test-test",
+                "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+                "repo": {
+                  "name": "merge-me-test"
+                }
+              },
+              "base": {
+                "ref": "master",
+                "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+                "repo": {
+                  "name": "merge-me-test"
+                }
+              }
+            }
+          ],
+          "app": {
+            "slug": "merge-me-test-app2",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            },
+            "name": "merge-me-test-app2",
+            "permissions": {
+              "actions": "write",
+              "administration": "write",
+              "blocking": "write",
+              "checks": "write",
+              "contents": "write",
+              "deployments": "write",
+              "emails": "write",
+              "followers": "write",
+              "gpg_keys": "write",
+              "issues": "write",
+              "keys": "write",
+              "members": "write",
+              "metadata": "read",
+              "organization_administration": "write",
+              "organization_hooks": "write",
+              "organization_plan": "read",
+              "organization_projects": "admin",
+              "organization_secrets": "write",
+              "organization_self_hosted_runners": "write",
+              "organization_user_blocking": "write",
+              "pages": "write",
+              "plan": "read",
+              "pull_requests": "write",
+              "repository_hooks": "write",
+              "repository_projects": "admin",
+              "secrets": "write",
+              "security_events": "write",
+              "starring": "write",
+              "statuses": "write",
+              "team_discussions": "write",
+              "vulnerability_alerts": "read",
+              "watching": "write",
+              "workflows": "write"
+            },
+            "events": [
+              "check_run",
+              "check_suite",
+              "commit_comment",
+              "create",
+              "delete",
+              "deployment",
+              "deployment_status",
+              "deploy_key",
+              "fork",
+              "gollum",
+              "issues",
+              "issue_comment",
+              "label",
+              "member",
+              "membership",
+              "milestone",
+              "organization",
+              "org_block",
+              "page_build",
+              "project",
+              "project_card",
+              "project_column",
+              "public",
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment",
+              "push",
+              "release",
+              "repository",
+              "repository_dispatch",
+              "star",
+              "status",
+              "team",
+              "team_add",
+              "watch"
+            ]
+          },
+          "latest_check_runs_count": 0,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        },
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "completed",
+          "conclusion": "success",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [],
+          "app": {
+            "slug": "travis-ci",
+            "owner": {
+              "login": "travis-ci",
+              "type": "Organization"
+            },
+            "name": "Travis CI",
+            "permissions": {
+              "checks": "write",
+              "contents": "read",
+              "deployments": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "read",
+              "repository_hooks": "write",
+              "statuses": "write"
+            },
+            "events": [
+              "check_run",
+              "check_suite",
+              "create",
+              "delete",
+              "member",
+              "pull_request",
+              "push",
+              "repository"
+            ]
+          },
+          "latest_check_runs_count": 2,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        },
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "queued",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [],
+          "app": {
+            "slug": "dependabot",
+            "owner": {
+              "login": "github",
+              "type": "Organization"
+            },
+            "name": "Dependabot",
+            "permissions": {
+              "checks": "write",
+              "contents": "write",
+              "issues": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "write",
+              "statuses": "read",
+              "workflows": "write"
+            },
+            "events": [
+              "check_suite",
+              "issues",
+              "issue_comment",
+              "label",
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment",
+              "repository"
+            ]
+          },
+          "latest_check_runs_count": 0,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/review_teams_multi_team/039_repos.getContents.json
+++ b/test/fixtures/review_teams_multi_team/039_repos.getContents.json
@@ -1,0 +1,20 @@
+{
+  "name": "repos.getContents",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "path": ".github/merge-me.yml"
+  },
+  "result": {
+    "data": {
+      "name": "merge-me.yml",
+      "path": ".github/merge-me.yml",
+      "sha": "4c061e4bc0fff3dd9ffce937c320fdead239b564",
+      "size": 28,
+      "type": "file",
+      "content": "cmV2aWV3VGVhbXM6Ci0gZGV2Ci0gZGVzaWduCg==\n",
+      "encoding": "base64"
+    }
+  }
+}

--- a/test/fixtures/review_teams_multi_team/040_pullRequests.listReviews.json
+++ b/test/fixtures/review_teams_multi_team/040_pullRequests.listReviews.json
@@ -1,0 +1,31 @@
+{
+  "name": "pullRequests.listReviews",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "number": 12
+  },
+  "result": {
+    "data": [
+      {
+        "user": {
+          "login": "notoguz2",
+          "type": "User"
+        },
+        "state": "APPROVED",
+        "author_association": "MEMBER",
+        "commit_id": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+      },
+      {
+        "user": {
+          "login": "notoguz",
+          "type": "User"
+        },
+        "state": "APPROVED",
+        "author_association": "MEMBER",
+        "commit_id": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+      }
+    ]
+  }
+}

--- a/test/fixtures/review_teams_multi_team/041_teams.list.json
+++ b/test/fixtures/review_teams_multi_team/041_teams.list.json
@@ -1,0 +1,31 @@
+{
+  "name": "teams.list",
+  "type": "api-call",
+  "args": {
+    "org": "Merge-Me-Test-Organisation"
+  },
+  "result": {
+    "data": [
+      {
+        "name": "design",
+        "id": 3861523,
+        "slug": "design",
+        "privacy": "closed",
+        "permission": "pull"
+      },
+      {
+        "name": "dev",
+        "id": 3861522,
+        "slug": "dev",
+        "privacy": "closed",
+        "permission": "pull"
+      },
+      {
+        "name": "testteam123",
+        "slug": "testteam123",
+        "privacy": "closed",
+        "permission": "pull"
+      }
+    ]
+  }
+}

--- a/test/fixtures/review_teams_multi_team/042_teams.listMembers.json
+++ b/test/fixtures/review_teams_multi_team/042_teams.listMembers.json
@@ -1,0 +1,24 @@
+{
+  "name": "teams.listMembers",
+  "type": "api-call",
+  "args": {
+    "org": "Merge-Me-Test-Organisation",
+    "team_id": 3861523
+  },
+  "result": {
+    "data": [
+      {
+        "login": "oguzeroglu",
+        "type": "User"
+      },
+      {
+        "login": "notoguz",
+        "type": "User"
+      },
+      {
+        "login": "notoguz2",
+        "type": "User"
+      }
+    ]
+  }
+}

--- a/test/fixtures/review_teams_multi_team/043_teams.listMembers.json
+++ b/test/fixtures/review_teams_multi_team/043_teams.listMembers.json
@@ -1,0 +1,20 @@
+{
+  "name": "teams.listMembers",
+  "type": "api-call",
+  "args": {
+    "org": "Merge-Me-Test-Organisation",
+    "team_id": 3861522
+  },
+  "result": {
+    "data": [
+      {
+        "login": "oguzeroglu",
+        "type": "User"
+      },
+      {
+        "login": "notoguz2",
+        "type": "User"
+      }
+    ]
+  }
+}

--- a/test/fixtures/review_teams_multi_team/053_pullRequests.merge.json
+++ b/test/fixtures/review_teams_multi_team/053_pullRequests.merge.json
@@ -1,0 +1,18 @@
+{
+  "name": "pullRequests.merge",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "number": 12,
+    "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+    "merge_method": "rebase"
+  },
+  "result": {
+    "data": {
+      "sha": "de6823ae07b63a7ba4e263f3f9cba7ce015ae650",
+      "merged": true,
+      "message": "Pull Request successfully merged"
+    }
+  }
+}

--- a/test/fixtures/review_teams_multi_team/054_pull_request.closed.json
+++ b/test/fixtures/review_teams_multi_team/054_pull_request.closed.json
@@ -1,0 +1,108 @@
+{
+  "name": "pull_request.closed",
+  "type": "event",
+  "payload": {
+    "action": "closed",
+    "number": 12,
+    "pull_request": {
+      "number": 12,
+      "state": "closed",
+      "title": "feat: test",
+      "user": {
+        "login": "oguzeroglu",
+        "type": "User"
+      },
+      "merge_commit_sha": "de6823ae07b63a7ba4e263f3f9cba7ce015ae650",
+      "assignees": [],
+      "requested_reviewers": [],
+      "requested_teams": [],
+      "labels": [],
+      "draft": false,
+      "head": {
+        "label": "Merge-Me-Test-Organisation:test-test",
+        "ref": "test-test",
+        "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+        "user": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        },
+        "repo": {
+          "name": "merge-me-test",
+          "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+          "owner": {
+            "login": "Merge-Me-Test-Organisation",
+            "type": "Organization"
+          },
+          "size": 16,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 0,
+          "forks": 0,
+          "open_issues": 0,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "base": {
+        "label": "Merge-Me-Test-Organisation:master",
+        "ref": "master",
+        "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+        "user": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        },
+        "repo": {
+          "name": "merge-me-test",
+          "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+          "owner": {
+            "login": "Merge-Me-Test-Organisation",
+            "type": "Organization"
+          },
+          "size": 16,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 0,
+          "forks": 0,
+          "open_issues": 0,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "author_association": "MEMBER",
+      "merged": true,
+      "mergeable_state": "unknown",
+      "merged_by": {
+        "login": "merge-me-test-app2[bot]",
+        "type": "Bot"
+      },
+      "comments": 0,
+      "review_comments": 0,
+      "commits": 2,
+      "additions": 2,
+      "deletions": 0,
+      "changed_files": 2
+    },
+    "repository": {
+      "name": "merge-me-test",
+      "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+      "owner": {
+        "login": "Merge-Me-Test-Organisation",
+        "type": "Organization"
+      },
+      "size": 16,
+      "stargazers_count": 0,
+      "watchers_count": 0,
+      "forks_count": 0,
+      "open_issues_count": 0,
+      "forks": 0,
+      "open_issues": 0,
+      "watchers": 0,
+      "default_branch": "master"
+    },
+    "organization": {
+      "login": "Merge-Me-Test-Organisation"
+    }
+  }
+}

--- a/test/fixtures/review_teams_simple/028_check_suite.completed.json
+++ b/test/fixtures/review_teams_simple/028_check_suite.completed.json
@@ -1,0 +1,94 @@
+{
+  "name": "check_suite.completed",
+  "type": "event",
+  "payload": {
+    "action": "completed",
+    "check_suite": {
+      "head_branch": "test-test",
+      "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "status": "completed",
+      "conclusion": "success",
+      "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+      "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "pull_requests": [
+        {
+          "number": 12,
+          "head": {
+            "ref": "test-test",
+            "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+            "repo": {
+              "name": "merge-me-test"
+            }
+          },
+          "base": {
+            "ref": "master",
+            "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+            "repo": {
+              "name": "merge-me-test"
+            }
+          }
+        }
+      ],
+      "app": {
+        "slug": "travis-ci",
+        "owner": {
+          "login": "travis-ci",
+          "type": "Organization"
+        },
+        "name": "Travis CI",
+        "permissions": {
+          "checks": "write",
+          "contents": "read",
+          "deployments": "write",
+          "members": "read",
+          "metadata": "read",
+          "pull_requests": "read",
+          "repository_hooks": "write",
+          "statuses": "write"
+        },
+        "events": [
+          "check_run",
+          "check_suite",
+          "create",
+          "delete",
+          "member",
+          "pull_request",
+          "push",
+          "repository"
+        ]
+      },
+      "latest_check_runs_count": 2,
+      "head_commit": {
+        "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+        "message": "feat: test2",
+        "timestamp": "2020-05-28T08:47:11Z",
+        "author": {
+          "name": "Oguz"
+        },
+        "committer": {
+          "name": "Oguz"
+        }
+      }
+    },
+    "repository": {
+      "name": "merge-me-test",
+      "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+      "owner": {
+        "login": "Merge-Me-Test-Organisation",
+        "type": "Organization"
+      },
+      "size": 16,
+      "stargazers_count": 0,
+      "watchers_count": 0,
+      "forks_count": 0,
+      "open_issues_count": 1,
+      "forks": 0,
+      "open_issues": 1,
+      "watchers": 0,
+      "default_branch": "master"
+    },
+    "organization": {
+      "login": "Merge-Me-Test-Organisation"
+    }
+  }
+}

--- a/test/fixtures/review_teams_simple/030_repos.getBranchProtection.json
+++ b/test/fixtures/review_teams_simple/030_repos.getBranchProtection.json
@@ -1,0 +1,59 @@
+{
+  "name": "repos.getBranchProtection",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "branch": "master"
+  },
+  "result": {
+    "error": {
+      "name": "HttpError",
+      "status": 404,
+      "headers": {
+        "access-control-allow-origin": "*",
+        "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset",
+        "connection": "close",
+        "content-encoding": "gzip",
+        "content-security-policy": "default-src 'none'",
+        "content-type": "application/json; charset=utf-8",
+        "referrer-policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+        "server": "GitHub.com",
+        "status": "404 Not Found",
+        "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
+        "transfer-encoding": "chunked",
+        "vary": "Accept-Encoding, Accept, X-Requested-With",
+        "x-content-type-options": "nosniff",
+        "x-frame-options": "deny",
+        "x-github-media-type": "github.v3; format=json",
+        "x-github-request-id": "49A9:2616C:16C612F:1A8A370:5ECF7AE7",
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-remaining": "4949",
+        "x-ratelimit-reset": "1590657537",
+        "x-xss-protection": "1; mode=block"
+      },
+      "request": {
+        "method": "GET",
+        "headers": {
+          "accept": "application/vnd.github.v3+json",
+          "user-agent": "octokit.js/16.20.0 Node.js/12.9.1 (macOS Mojave; x64)",
+          "authorization": "token [REDACTED]"
+        },
+        "request": {
+          "validate": {
+            "branch": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "repo": {
+              "type": "string"
+            }
+          },
+          "retryCount": 1
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/review_teams_simple/031_repos.getCombinedStatusForRef.json
+++ b/test/fixtures/review_teams_simple/031_repos.getCombinedStatusForRef.json
@@ -1,0 +1,25 @@
+{
+  "name": "repos.getCombinedStatusForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "ref": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+  },
+  "result": {
+    "data": {
+      "state": "pending",
+      "statuses": [],
+      "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "total_count": 0,
+      "repository": {
+        "name": "merge-me-test",
+        "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+        "owner": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/review_teams_simple/032_checks.listSuitesForRef.json
+++ b/test/fixtures/review_teams_simple/032_checks.listSuitesForRef.json
@@ -1,0 +1,255 @@
+{
+  "name": "checks.listSuitesForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "ref": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+  },
+  "result": {
+    "data": {
+      "total_count": 3,
+      "check_suites": [
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "queued",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [
+            {
+              "number": 12,
+              "head": {
+                "ref": "test-test",
+                "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+                "repo": {
+                  "name": "merge-me-test"
+                }
+              },
+              "base": {
+                "ref": "master",
+                "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+                "repo": {
+                  "name": "merge-me-test"
+                }
+              }
+            }
+          ],
+          "app": {
+            "slug": "merge-me-test-app2",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            },
+            "name": "merge-me-test-app2",
+            "permissions": {
+              "actions": "write",
+              "administration": "write",
+              "blocking": "write",
+              "checks": "write",
+              "contents": "write",
+              "deployments": "write",
+              "emails": "write",
+              "followers": "write",
+              "gpg_keys": "write",
+              "issues": "write",
+              "keys": "write",
+              "members": "write",
+              "metadata": "read",
+              "organization_administration": "write",
+              "organization_hooks": "write",
+              "organization_plan": "read",
+              "organization_projects": "admin",
+              "organization_secrets": "write",
+              "organization_self_hosted_runners": "write",
+              "organization_user_blocking": "write",
+              "pages": "write",
+              "plan": "read",
+              "pull_requests": "write",
+              "repository_hooks": "write",
+              "repository_projects": "admin",
+              "secrets": "write",
+              "security_events": "write",
+              "starring": "write",
+              "statuses": "write",
+              "team_discussions": "write",
+              "vulnerability_alerts": "read",
+              "watching": "write",
+              "workflows": "write"
+            },
+            "events": [
+              "check_run",
+              "check_suite",
+              "commit_comment",
+              "create",
+              "delete",
+              "deployment",
+              "deployment_status",
+              "deploy_key",
+              "fork",
+              "gollum",
+              "issues",
+              "issue_comment",
+              "label",
+              "member",
+              "membership",
+              "milestone",
+              "organization",
+              "org_block",
+              "page_build",
+              "project",
+              "project_card",
+              "project_column",
+              "public",
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment",
+              "push",
+              "release",
+              "repository",
+              "repository_dispatch",
+              "star",
+              "status",
+              "team",
+              "team_add",
+              "watch"
+            ]
+          },
+          "latest_check_runs_count": 0,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        },
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "completed",
+          "conclusion": "success",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [],
+          "app": {
+            "slug": "travis-ci",
+            "owner": {
+              "login": "travis-ci",
+              "type": "Organization"
+            },
+            "name": "Travis CI",
+            "permissions": {
+              "checks": "write",
+              "contents": "read",
+              "deployments": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "read",
+              "repository_hooks": "write",
+              "statuses": "write"
+            },
+            "events": [
+              "check_run",
+              "check_suite",
+              "create",
+              "delete",
+              "member",
+              "pull_request",
+              "push",
+              "repository"
+            ]
+          },
+          "latest_check_runs_count": 2,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        },
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "queued",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [],
+          "app": {
+            "slug": "dependabot",
+            "owner": {
+              "login": "github",
+              "type": "Organization"
+            },
+            "name": "Dependabot",
+            "permissions": {
+              "checks": "write",
+              "contents": "write",
+              "issues": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "write",
+              "statuses": "read",
+              "workflows": "write"
+            },
+            "events": [
+              "check_suite",
+              "issues",
+              "issue_comment",
+              "label",
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment",
+              "repository"
+            ]
+          },
+          "latest_check_runs_count": 0,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/review_teams_simple/033_repos.getContents.json
+++ b/test/fixtures/review_teams_simple/033_repos.getContents.json
@@ -1,0 +1,20 @@
+{
+  "name": "repos.getContents",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "path": ".github/merge-me.yml"
+  },
+  "result": {
+    "data": {
+      "name": "merge-me.yml",
+      "path": ".github/merge-me.yml",
+      "sha": "4c061e4bc0fff3dd9ffce937c320fdead239b564",
+      "size": 28,
+      "type": "file",
+      "content": "cmV2aWV3VGVhbXM6Ci0gZGV2Ci0gZGVzaWduCg==\n",
+      "encoding": "base64"
+    }
+  }
+}

--- a/test/fixtures/review_teams_simple/034_pullRequests.listReviews.json
+++ b/test/fixtures/review_teams_simple/034_pullRequests.listReviews.json
@@ -1,0 +1,12 @@
+{
+  "name": "pullRequests.listReviews",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "number": 12
+  },
+  "result": {
+    "data": []
+  }
+}

--- a/test/fixtures/review_teams_simple/035_pull_request_review.submitted.json
+++ b/test/fixtures/review_teams_simple/035_pull_request_review.submitted.json
@@ -1,0 +1,109 @@
+{
+  "name": "pull_request_review.submitted",
+  "type": "event",
+  "payload": {
+    "action": "submitted",
+    "review": {
+      "user": {
+        "login": "notoguz2",
+        "type": "User"
+      },
+      "commit_id": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "state": "approved",
+      "author_association": "NONE"
+    },
+    "pull_request": {
+      "number": 12,
+      "state": "open",
+      "title": "feat: test",
+      "user": {
+        "login": "oguzeroglu",
+        "type": "User"
+      },
+      "merge_commit_sha": "fb6bd8d36aaa8bd88d51feee985ed6d10e311520",
+      "assignees": [],
+      "requested_reviewers": [
+        {
+          "login": "notoguz",
+          "type": "User"
+        }
+      ],
+      "requested_teams": [],
+      "labels": [],
+      "draft": false,
+      "head": {
+        "label": "Merge-Me-Test-Organisation:test-test",
+        "ref": "test-test",
+        "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+        "user": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        },
+        "repo": {
+          "name": "merge-me-test",
+          "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+          "owner": {
+            "login": "Merge-Me-Test-Organisation",
+            "type": "Organization"
+          },
+          "size": 16,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 1,
+          "forks": 0,
+          "open_issues": 1,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "base": {
+        "label": "Merge-Me-Test-Organisation:master",
+        "ref": "master",
+        "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+        "user": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        },
+        "repo": {
+          "name": "merge-me-test",
+          "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+          "owner": {
+            "login": "Merge-Me-Test-Organisation",
+            "type": "Organization"
+          },
+          "size": 16,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 1,
+          "forks": 0,
+          "open_issues": 1,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "author_association": "MEMBER"
+    },
+    "repository": {
+      "name": "merge-me-test",
+      "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+      "owner": {
+        "login": "Merge-Me-Test-Organisation",
+        "type": "Organization"
+      },
+      "size": 16,
+      "stargazers_count": 0,
+      "watchers_count": 0,
+      "forks_count": 0,
+      "open_issues_count": 1,
+      "forks": 0,
+      "open_issues": 1,
+      "watchers": 0,
+      "default_branch": "master"
+    },
+    "organization": {
+      "login": "Merge-Me-Test-Organisation"
+    }
+  }
+}

--- a/test/fixtures/review_teams_simple/036_repos.getBranchProtection.json
+++ b/test/fixtures/review_teams_simple/036_repos.getBranchProtection.json
@@ -1,0 +1,59 @@
+{
+  "name": "repos.getBranchProtection",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "branch": "master"
+  },
+  "result": {
+    "error": {
+      "name": "HttpError",
+      "status": 404,
+      "headers": {
+        "access-control-allow-origin": "*",
+        "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset",
+        "connection": "close",
+        "content-encoding": "gzip",
+        "content-security-policy": "default-src 'none'",
+        "content-type": "application/json; charset=utf-8",
+        "referrer-policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+        "server": "GitHub.com",
+        "status": "404 Not Found",
+        "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
+        "transfer-encoding": "chunked",
+        "vary": "Accept-Encoding, Accept, X-Requested-With",
+        "x-content-type-options": "nosniff",
+        "x-frame-options": "deny",
+        "x-github-media-type": "github.v3; format=json",
+        "x-github-request-id": "490E:81D5:5370D6:609E5B:5ECF7B06",
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-remaining": "4944",
+        "x-ratelimit-reset": "1590657536",
+        "x-xss-protection": "1; mode=block"
+      },
+      "request": {
+        "method": "GET",
+        "headers": {
+          "accept": "application/vnd.github.v3+json",
+          "user-agent": "octokit.js/16.20.0 Node.js/12.9.1 (macOS Mojave; x64)",
+          "authorization": "token [REDACTED]"
+        },
+        "request": {
+          "validate": {
+            "branch": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "repo": {
+              "type": "string"
+            }
+          },
+          "retryCount": 1
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/review_teams_simple/037_repos.getCombinedStatusForRef.json
+++ b/test/fixtures/review_teams_simple/037_repos.getCombinedStatusForRef.json
@@ -1,0 +1,25 @@
+{
+  "name": "repos.getCombinedStatusForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "ref": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+  },
+  "result": {
+    "data": {
+      "state": "pending",
+      "statuses": [],
+      "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "total_count": 0,
+      "repository": {
+        "name": "merge-me-test",
+        "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+        "owner": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/review_teams_simple/038_checks.listSuitesForRef.json
+++ b/test/fixtures/review_teams_simple/038_checks.listSuitesForRef.json
@@ -1,0 +1,255 @@
+{
+  "name": "checks.listSuitesForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "ref": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+  },
+  "result": {
+    "data": {
+      "total_count": 3,
+      "check_suites": [
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "queued",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [
+            {
+              "number": 12,
+              "head": {
+                "ref": "test-test",
+                "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+                "repo": {
+                  "name": "merge-me-test"
+                }
+              },
+              "base": {
+                "ref": "master",
+                "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+                "repo": {
+                  "name": "merge-me-test"
+                }
+              }
+            }
+          ],
+          "app": {
+            "slug": "merge-me-test-app2",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            },
+            "name": "merge-me-test-app2",
+            "permissions": {
+              "actions": "write",
+              "administration": "write",
+              "blocking": "write",
+              "checks": "write",
+              "contents": "write",
+              "deployments": "write",
+              "emails": "write",
+              "followers": "write",
+              "gpg_keys": "write",
+              "issues": "write",
+              "keys": "write",
+              "members": "write",
+              "metadata": "read",
+              "organization_administration": "write",
+              "organization_hooks": "write",
+              "organization_plan": "read",
+              "organization_projects": "admin",
+              "organization_secrets": "write",
+              "organization_self_hosted_runners": "write",
+              "organization_user_blocking": "write",
+              "pages": "write",
+              "plan": "read",
+              "pull_requests": "write",
+              "repository_hooks": "write",
+              "repository_projects": "admin",
+              "secrets": "write",
+              "security_events": "write",
+              "starring": "write",
+              "statuses": "write",
+              "team_discussions": "write",
+              "vulnerability_alerts": "read",
+              "watching": "write",
+              "workflows": "write"
+            },
+            "events": [
+              "check_run",
+              "check_suite",
+              "commit_comment",
+              "create",
+              "delete",
+              "deployment",
+              "deployment_status",
+              "deploy_key",
+              "fork",
+              "gollum",
+              "issues",
+              "issue_comment",
+              "label",
+              "member",
+              "membership",
+              "milestone",
+              "organization",
+              "org_block",
+              "page_build",
+              "project",
+              "project_card",
+              "project_column",
+              "public",
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment",
+              "push",
+              "release",
+              "repository",
+              "repository_dispatch",
+              "star",
+              "status",
+              "team",
+              "team_add",
+              "watch"
+            ]
+          },
+          "latest_check_runs_count": 0,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        },
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "completed",
+          "conclusion": "success",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [],
+          "app": {
+            "slug": "travis-ci",
+            "owner": {
+              "login": "travis-ci",
+              "type": "Organization"
+            },
+            "name": "Travis CI",
+            "permissions": {
+              "checks": "write",
+              "contents": "read",
+              "deployments": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "read",
+              "repository_hooks": "write",
+              "statuses": "write"
+            },
+            "events": [
+              "check_run",
+              "check_suite",
+              "create",
+              "delete",
+              "member",
+              "pull_request",
+              "push",
+              "repository"
+            ]
+          },
+          "latest_check_runs_count": 2,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        },
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "queued",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [],
+          "app": {
+            "slug": "dependabot",
+            "owner": {
+              "login": "github",
+              "type": "Organization"
+            },
+            "name": "Dependabot",
+            "permissions": {
+              "checks": "write",
+              "contents": "write",
+              "issues": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "write",
+              "statuses": "read",
+              "workflows": "write"
+            },
+            "events": [
+              "check_suite",
+              "issues",
+              "issue_comment",
+              "label",
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment",
+              "repository"
+            ]
+          },
+          "latest_check_runs_count": 0,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/review_teams_simple/039_repos.getContents.json
+++ b/test/fixtures/review_teams_simple/039_repos.getContents.json
@@ -1,0 +1,20 @@
+{
+  "name": "repos.getContents",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "path": ".github/merge-me.yml"
+  },
+  "result": {
+    "data": {
+      "name": "merge-me.yml",
+      "path": ".github/merge-me.yml",
+      "sha": "4c061e4bc0fff3dd9ffce937c320fdead239b564",
+      "size": 28,
+      "type": "file",
+      "content": "cmV2aWV3VGVhbXM6Ci0gZGV2Ci0gZGVzaWduCg==\n",
+      "encoding": "base64"
+    }
+  }
+}

--- a/test/fixtures/review_teams_simple/040_pullRequests.listReviews.json
+++ b/test/fixtures/review_teams_simple/040_pullRequests.listReviews.json
@@ -1,0 +1,31 @@
+{
+  "name": "pullRequests.listReviews",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "number": 12
+  },
+  "result": {
+    "data": [
+      {
+        "user": {
+          "login": "notoguz2",
+          "type": "User"
+        },
+        "state": "APPROVED",
+        "author_association": "MEMBER",
+        "commit_id": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+      },
+      {
+        "user": {
+          "login": "notoguz",
+          "type": "User"
+        },
+        "state": "APPROVED",
+        "author_association": "MEMBER",
+        "commit_id": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+      }
+    ]
+  }
+}

--- a/test/fixtures/review_teams_simple/041_teams.list.json
+++ b/test/fixtures/review_teams_simple/041_teams.list.json
@@ -1,0 +1,31 @@
+{
+  "name": "teams.list",
+  "type": "api-call",
+  "args": {
+    "org": "Merge-Me-Test-Organisation"
+  },
+  "result": {
+    "data": [
+      {
+        "name": "design",
+        "id": 3861523,
+        "slug": "design",
+        "privacy": "closed",
+        "permission": "pull"
+      },
+      {
+        "name": "dev",
+        "id": 3861522,
+        "slug": "dev",
+        "privacy": "closed",
+        "permission": "pull"
+      },
+      {
+        "name": "testteam123",
+        "slug": "testteam123",
+        "privacy": "closed",
+        "permission": "pull"
+      }
+    ]
+  }
+}

--- a/test/fixtures/review_teams_simple/042_teams.listMembers.json
+++ b/test/fixtures/review_teams_simple/042_teams.listMembers.json
@@ -1,0 +1,20 @@
+{
+  "name": "teams.listMembers",
+  "type": "api-call",
+  "args": {
+    "org": "Merge-Me-Test-Organisation",
+    "team_id": 3861523
+  },
+  "result": {
+    "data": [
+      {
+        "login": "oguzeroglu",
+        "type": "User"
+      },
+      {
+        "login": "notoguz",
+        "type": "User"
+      }
+    ]
+  }
+}

--- a/test/fixtures/review_teams_simple/043_teams.listMembers.json
+++ b/test/fixtures/review_teams_simple/043_teams.listMembers.json
@@ -1,0 +1,20 @@
+{
+  "name": "teams.listMembers",
+  "type": "api-call",
+  "args": {
+    "org": "Merge-Me-Test-Organisation",
+    "team_id": 3861522
+  },
+  "result": {
+    "data": [
+      {
+        "login": "oguzeroglu",
+        "type": "User"
+      },
+      {
+        "login": "notoguz2",
+        "type": "User"
+      }
+    ]
+  }
+}

--- a/test/fixtures/review_teams_simple/053_pullRequests.merge.json
+++ b/test/fixtures/review_teams_simple/053_pullRequests.merge.json
@@ -1,0 +1,18 @@
+{
+  "name": "pullRequests.merge",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "number": 12,
+    "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+    "merge_method": "rebase"
+  },
+  "result": {
+    "data": {
+      "sha": "de6823ae07b63a7ba4e263f3f9cba7ce015ae650",
+      "merged": true,
+      "message": "Pull Request successfully merged"
+    }
+  }
+}

--- a/test/fixtures/review_teams_simple/054_pull_request.closed.json
+++ b/test/fixtures/review_teams_simple/054_pull_request.closed.json
@@ -1,0 +1,108 @@
+{
+  "name": "pull_request.closed",
+  "type": "event",
+  "payload": {
+    "action": "closed",
+    "number": 12,
+    "pull_request": {
+      "number": 12,
+      "state": "closed",
+      "title": "feat: test",
+      "user": {
+        "login": "oguzeroglu",
+        "type": "User"
+      },
+      "merge_commit_sha": "de6823ae07b63a7ba4e263f3f9cba7ce015ae650",
+      "assignees": [],
+      "requested_reviewers": [],
+      "requested_teams": [],
+      "labels": [],
+      "draft": false,
+      "head": {
+        "label": "Merge-Me-Test-Organisation:test-test",
+        "ref": "test-test",
+        "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+        "user": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        },
+        "repo": {
+          "name": "merge-me-test",
+          "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+          "owner": {
+            "login": "Merge-Me-Test-Organisation",
+            "type": "Organization"
+          },
+          "size": 16,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 0,
+          "forks": 0,
+          "open_issues": 0,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "base": {
+        "label": "Merge-Me-Test-Organisation:master",
+        "ref": "master",
+        "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+        "user": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        },
+        "repo": {
+          "name": "merge-me-test",
+          "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+          "owner": {
+            "login": "Merge-Me-Test-Organisation",
+            "type": "Organization"
+          },
+          "size": 16,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 0,
+          "forks": 0,
+          "open_issues": 0,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "author_association": "MEMBER",
+      "merged": true,
+      "mergeable_state": "unknown",
+      "merged_by": {
+        "login": "merge-me-test-app2[bot]",
+        "type": "Bot"
+      },
+      "comments": 0,
+      "review_comments": 0,
+      "commits": 2,
+      "additions": 2,
+      "deletions": 0,
+      "changed_files": 2
+    },
+    "repository": {
+      "name": "merge-me-test",
+      "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+      "owner": {
+        "login": "Merge-Me-Test-Organisation",
+        "type": "Organization"
+      },
+      "size": 16,
+      "stargazers_count": 0,
+      "watchers_count": 0,
+      "forks_count": 0,
+      "open_issues_count": 0,
+      "forks": 0,
+      "open_issues": 0,
+      "watchers": 0,
+      "default_branch": "master"
+    },
+    "organization": {
+      "login": "Merge-Me-Test-Organisation"
+    }
+  }
+}

--- a/test/fixtures/review_teams_with_rejects/028_check_suite.completed.json
+++ b/test/fixtures/review_teams_with_rejects/028_check_suite.completed.json
@@ -1,0 +1,94 @@
+{
+  "name": "check_suite.completed",
+  "type": "event",
+  "payload": {
+    "action": "completed",
+    "check_suite": {
+      "head_branch": "test-test",
+      "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "status": "completed",
+      "conclusion": "success",
+      "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+      "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "pull_requests": [
+        {
+          "number": 12,
+          "head": {
+            "ref": "test-test",
+            "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+            "repo": {
+              "name": "merge-me-test"
+            }
+          },
+          "base": {
+            "ref": "master",
+            "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+            "repo": {
+              "name": "merge-me-test"
+            }
+          }
+        }
+      ],
+      "app": {
+        "slug": "travis-ci",
+        "owner": {
+          "login": "travis-ci",
+          "type": "Organization"
+        },
+        "name": "Travis CI",
+        "permissions": {
+          "checks": "write",
+          "contents": "read",
+          "deployments": "write",
+          "members": "read",
+          "metadata": "read",
+          "pull_requests": "read",
+          "repository_hooks": "write",
+          "statuses": "write"
+        },
+        "events": [
+          "check_run",
+          "check_suite",
+          "create",
+          "delete",
+          "member",
+          "pull_request",
+          "push",
+          "repository"
+        ]
+      },
+      "latest_check_runs_count": 2,
+      "head_commit": {
+        "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+        "message": "feat: test2",
+        "timestamp": "2020-05-28T08:47:11Z",
+        "author": {
+          "name": "Oguz"
+        },
+        "committer": {
+          "name": "Oguz"
+        }
+      }
+    },
+    "repository": {
+      "name": "merge-me-test",
+      "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+      "owner": {
+        "login": "Merge-Me-Test-Organisation",
+        "type": "Organization"
+      },
+      "size": 16,
+      "stargazers_count": 0,
+      "watchers_count": 0,
+      "forks_count": 0,
+      "open_issues_count": 1,
+      "forks": 0,
+      "open_issues": 1,
+      "watchers": 0,
+      "default_branch": "master"
+    },
+    "organization": {
+      "login": "Merge-Me-Test-Organisation"
+    }
+  }
+}

--- a/test/fixtures/review_teams_with_rejects/030_repos.getBranchProtection.json
+++ b/test/fixtures/review_teams_with_rejects/030_repos.getBranchProtection.json
@@ -1,0 +1,59 @@
+{
+  "name": "repos.getBranchProtection",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "branch": "master"
+  },
+  "result": {
+    "error": {
+      "name": "HttpError",
+      "status": 404,
+      "headers": {
+        "access-control-allow-origin": "*",
+        "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset",
+        "connection": "close",
+        "content-encoding": "gzip",
+        "content-security-policy": "default-src 'none'",
+        "content-type": "application/json; charset=utf-8",
+        "referrer-policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+        "server": "GitHub.com",
+        "status": "404 Not Found",
+        "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
+        "transfer-encoding": "chunked",
+        "vary": "Accept-Encoding, Accept, X-Requested-With",
+        "x-content-type-options": "nosniff",
+        "x-frame-options": "deny",
+        "x-github-media-type": "github.v3; format=json",
+        "x-github-request-id": "49A9:2616C:16C612F:1A8A370:5ECF7AE7",
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-remaining": "4949",
+        "x-ratelimit-reset": "1590657537",
+        "x-xss-protection": "1; mode=block"
+      },
+      "request": {
+        "method": "GET",
+        "headers": {
+          "accept": "application/vnd.github.v3+json",
+          "user-agent": "octokit.js/16.20.0 Node.js/12.9.1 (macOS Mojave; x64)",
+          "authorization": "token [REDACTED]"
+        },
+        "request": {
+          "validate": {
+            "branch": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "repo": {
+              "type": "string"
+            }
+          },
+          "retryCount": 1
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/review_teams_with_rejects/031_repos.getCombinedStatusForRef.json
+++ b/test/fixtures/review_teams_with_rejects/031_repos.getCombinedStatusForRef.json
@@ -1,0 +1,25 @@
+{
+  "name": "repos.getCombinedStatusForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "ref": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+  },
+  "result": {
+    "data": {
+      "state": "pending",
+      "statuses": [],
+      "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "total_count": 0,
+      "repository": {
+        "name": "merge-me-test",
+        "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+        "owner": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/review_teams_with_rejects/032_checks.listSuitesForRef.json
+++ b/test/fixtures/review_teams_with_rejects/032_checks.listSuitesForRef.json
@@ -1,0 +1,255 @@
+{
+  "name": "checks.listSuitesForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "ref": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+  },
+  "result": {
+    "data": {
+      "total_count": 3,
+      "check_suites": [
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "queued",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [
+            {
+              "number": 12,
+              "head": {
+                "ref": "test-test",
+                "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+                "repo": {
+                  "name": "merge-me-test"
+                }
+              },
+              "base": {
+                "ref": "master",
+                "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+                "repo": {
+                  "name": "merge-me-test"
+                }
+              }
+            }
+          ],
+          "app": {
+            "slug": "merge-me-test-app2",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            },
+            "name": "merge-me-test-app2",
+            "permissions": {
+              "actions": "write",
+              "administration": "write",
+              "blocking": "write",
+              "checks": "write",
+              "contents": "write",
+              "deployments": "write",
+              "emails": "write",
+              "followers": "write",
+              "gpg_keys": "write",
+              "issues": "write",
+              "keys": "write",
+              "members": "write",
+              "metadata": "read",
+              "organization_administration": "write",
+              "organization_hooks": "write",
+              "organization_plan": "read",
+              "organization_projects": "admin",
+              "organization_secrets": "write",
+              "organization_self_hosted_runners": "write",
+              "organization_user_blocking": "write",
+              "pages": "write",
+              "plan": "read",
+              "pull_requests": "write",
+              "repository_hooks": "write",
+              "repository_projects": "admin",
+              "secrets": "write",
+              "security_events": "write",
+              "starring": "write",
+              "statuses": "write",
+              "team_discussions": "write",
+              "vulnerability_alerts": "read",
+              "watching": "write",
+              "workflows": "write"
+            },
+            "events": [
+              "check_run",
+              "check_suite",
+              "commit_comment",
+              "create",
+              "delete",
+              "deployment",
+              "deployment_status",
+              "deploy_key",
+              "fork",
+              "gollum",
+              "issues",
+              "issue_comment",
+              "label",
+              "member",
+              "membership",
+              "milestone",
+              "organization",
+              "org_block",
+              "page_build",
+              "project",
+              "project_card",
+              "project_column",
+              "public",
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment",
+              "push",
+              "release",
+              "repository",
+              "repository_dispatch",
+              "star",
+              "status",
+              "team",
+              "team_add",
+              "watch"
+            ]
+          },
+          "latest_check_runs_count": 0,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        },
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "completed",
+          "conclusion": "success",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [],
+          "app": {
+            "slug": "travis-ci",
+            "owner": {
+              "login": "travis-ci",
+              "type": "Organization"
+            },
+            "name": "Travis CI",
+            "permissions": {
+              "checks": "write",
+              "contents": "read",
+              "deployments": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "read",
+              "repository_hooks": "write",
+              "statuses": "write"
+            },
+            "events": [
+              "check_run",
+              "check_suite",
+              "create",
+              "delete",
+              "member",
+              "pull_request",
+              "push",
+              "repository"
+            ]
+          },
+          "latest_check_runs_count": 2,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        },
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "queued",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [],
+          "app": {
+            "slug": "dependabot",
+            "owner": {
+              "login": "github",
+              "type": "Organization"
+            },
+            "name": "Dependabot",
+            "permissions": {
+              "checks": "write",
+              "contents": "write",
+              "issues": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "write",
+              "statuses": "read",
+              "workflows": "write"
+            },
+            "events": [
+              "check_suite",
+              "issues",
+              "issue_comment",
+              "label",
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment",
+              "repository"
+            ]
+          },
+          "latest_check_runs_count": 0,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/review_teams_with_rejects/033_repos.getContents.json
+++ b/test/fixtures/review_teams_with_rejects/033_repos.getContents.json
@@ -1,0 +1,20 @@
+{
+  "name": "repos.getContents",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "path": ".github/merge-me.yml"
+  },
+  "result": {
+    "data": {
+      "name": "merge-me.yml",
+      "path": ".github/merge-me.yml",
+      "sha": "4c061e4bc0fff3dd9ffce937c320fdead239b564",
+      "size": 28,
+      "type": "file",
+      "content": "cmV2aWV3VGVhbXM6Ci0gZGV2Ci0gZGVzaWduCg==\n",
+      "encoding": "base64"
+    }
+  }
+}

--- a/test/fixtures/review_teams_with_rejects/034_pullRequests.listReviews.json
+++ b/test/fixtures/review_teams_with_rejects/034_pullRequests.listReviews.json
@@ -1,0 +1,12 @@
+{
+  "name": "pullRequests.listReviews",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "number": 12
+  },
+  "result": {
+    "data": []
+  }
+}

--- a/test/fixtures/review_teams_with_rejects/035_pull_request_review.submitted.json
+++ b/test/fixtures/review_teams_with_rejects/035_pull_request_review.submitted.json
@@ -1,0 +1,117 @@
+{
+  "name": "pull_request_review.submitted",
+  "type": "event",
+  "payload": {
+    "action": "submitted",
+    "review": {
+      "user": {
+        "login": "notoguz",
+        "type": "User"
+      },
+      "commit_id": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "state": "approved",
+      "author_association": "NONE"
+    },
+    "pull_request": {
+      "number": 12,
+      "state": "open",
+      "title": "feat: test",
+      "user": {
+        "login": "oguzeroglu",
+        "type": "User"
+      },
+      "merge_commit_sha": "fb6bd8d36aaa8bd88d51feee985ed6d10e311520",
+      "assignees": [],
+      "requested_reviewers": [
+        {
+          "login": "notoguz",
+          "type": "User"
+        },
+        {
+          "login": "notoguz2",
+          "type": "User"
+        },
+        {
+          "login": "notoguz3",
+          "type": "User"
+        }
+      ],
+      "requested_teams": [],
+      "labels": [],
+      "draft": false,
+      "head": {
+        "label": "Merge-Me-Test-Organisation:test-test",
+        "ref": "test-test",
+        "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+        "user": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        },
+        "repo": {
+          "name": "merge-me-test",
+          "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+          "owner": {
+            "login": "Merge-Me-Test-Organisation",
+            "type": "Organization"
+          },
+          "size": 16,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 1,
+          "forks": 0,
+          "open_issues": 1,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "base": {
+        "label": "Merge-Me-Test-Organisation:master",
+        "ref": "master",
+        "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+        "user": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        },
+        "repo": {
+          "name": "merge-me-test",
+          "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+          "owner": {
+            "login": "Merge-Me-Test-Organisation",
+            "type": "Organization"
+          },
+          "size": 16,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 1,
+          "forks": 0,
+          "open_issues": 1,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "author_association": "MEMBER"
+    },
+    "repository": {
+      "name": "merge-me-test",
+      "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+      "owner": {
+        "login": "Merge-Me-Test-Organisation",
+        "type": "Organization"
+      },
+      "size": 16,
+      "stargazers_count": 0,
+      "watchers_count": 0,
+      "forks_count": 0,
+      "open_issues_count": 1,
+      "forks": 0,
+      "open_issues": 1,
+      "watchers": 0,
+      "default_branch": "master"
+    },
+    "organization": {
+      "login": "Merge-Me-Test-Organisation"
+    }
+  }
+}

--- a/test/fixtures/review_teams_with_rejects/036_repos.getBranchProtection.json
+++ b/test/fixtures/review_teams_with_rejects/036_repos.getBranchProtection.json
@@ -1,0 +1,59 @@
+{
+  "name": "repos.getBranchProtection",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "branch": "master"
+  },
+  "result": {
+    "error": {
+      "name": "HttpError",
+      "status": 404,
+      "headers": {
+        "access-control-allow-origin": "*",
+        "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset",
+        "connection": "close",
+        "content-encoding": "gzip",
+        "content-security-policy": "default-src 'none'",
+        "content-type": "application/json; charset=utf-8",
+        "referrer-policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+        "server": "GitHub.com",
+        "status": "404 Not Found",
+        "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
+        "transfer-encoding": "chunked",
+        "vary": "Accept-Encoding, Accept, X-Requested-With",
+        "x-content-type-options": "nosniff",
+        "x-frame-options": "deny",
+        "x-github-media-type": "github.v3; format=json",
+        "x-github-request-id": "490E:81D5:5370D6:609E5B:5ECF7B06",
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-remaining": "4944",
+        "x-ratelimit-reset": "1590657536",
+        "x-xss-protection": "1; mode=block"
+      },
+      "request": {
+        "method": "GET",
+        "headers": {
+          "accept": "application/vnd.github.v3+json",
+          "user-agent": "octokit.js/16.20.0 Node.js/12.9.1 (macOS Mojave; x64)",
+          "authorization": "token [REDACTED]"
+        },
+        "request": {
+          "validate": {
+            "branch": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "repo": {
+              "type": "string"
+            }
+          },
+          "retryCount": 1
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/review_teams_with_rejects/037_repos.getCombinedStatusForRef.json
+++ b/test/fixtures/review_teams_with_rejects/037_repos.getCombinedStatusForRef.json
@@ -1,0 +1,25 @@
+{
+  "name": "repos.getCombinedStatusForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "ref": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+  },
+  "result": {
+    "data": {
+      "state": "pending",
+      "statuses": [],
+      "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+      "total_count": 0,
+      "repository": {
+        "name": "merge-me-test",
+        "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+        "owner": {
+          "login": "Merge-Me-Test-Organisation",
+          "type": "Organization"
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/review_teams_with_rejects/038_checks.listSuitesForRef.json
+++ b/test/fixtures/review_teams_with_rejects/038_checks.listSuitesForRef.json
@@ -1,0 +1,255 @@
+{
+  "name": "checks.listSuitesForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "ref": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+  },
+  "result": {
+    "data": {
+      "total_count": 3,
+      "check_suites": [
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "queued",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [
+            {
+              "number": 12,
+              "head": {
+                "ref": "test-test",
+                "sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+                "repo": {
+                  "name": "merge-me-test"
+                }
+              },
+              "base": {
+                "ref": "master",
+                "sha": "c97fa52a39aee73230b98a5faea7f27cadb0acc4",
+                "repo": {
+                  "name": "merge-me-test"
+                }
+              }
+            }
+          ],
+          "app": {
+            "slug": "merge-me-test-app2",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            },
+            "name": "merge-me-test-app2",
+            "permissions": {
+              "actions": "write",
+              "administration": "write",
+              "blocking": "write",
+              "checks": "write",
+              "contents": "write",
+              "deployments": "write",
+              "emails": "write",
+              "followers": "write",
+              "gpg_keys": "write",
+              "issues": "write",
+              "keys": "write",
+              "members": "write",
+              "metadata": "read",
+              "organization_administration": "write",
+              "organization_hooks": "write",
+              "organization_plan": "read",
+              "organization_projects": "admin",
+              "organization_secrets": "write",
+              "organization_self_hosted_runners": "write",
+              "organization_user_blocking": "write",
+              "pages": "write",
+              "plan": "read",
+              "pull_requests": "write",
+              "repository_hooks": "write",
+              "repository_projects": "admin",
+              "secrets": "write",
+              "security_events": "write",
+              "starring": "write",
+              "statuses": "write",
+              "team_discussions": "write",
+              "vulnerability_alerts": "read",
+              "watching": "write",
+              "workflows": "write"
+            },
+            "events": [
+              "check_run",
+              "check_suite",
+              "commit_comment",
+              "create",
+              "delete",
+              "deployment",
+              "deployment_status",
+              "deploy_key",
+              "fork",
+              "gollum",
+              "issues",
+              "issue_comment",
+              "label",
+              "member",
+              "membership",
+              "milestone",
+              "organization",
+              "org_block",
+              "page_build",
+              "project",
+              "project_card",
+              "project_column",
+              "public",
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment",
+              "push",
+              "release",
+              "repository",
+              "repository_dispatch",
+              "star",
+              "status",
+              "team",
+              "team_add",
+              "watch"
+            ]
+          },
+          "latest_check_runs_count": 0,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        },
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "completed",
+          "conclusion": "success",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [],
+          "app": {
+            "slug": "travis-ci",
+            "owner": {
+              "login": "travis-ci",
+              "type": "Organization"
+            },
+            "name": "Travis CI",
+            "permissions": {
+              "checks": "write",
+              "contents": "read",
+              "deployments": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "read",
+              "repository_hooks": "write",
+              "statuses": "write"
+            },
+            "events": [
+              "check_run",
+              "check_suite",
+              "create",
+              "delete",
+              "member",
+              "pull_request",
+              "push",
+              "repository"
+            ]
+          },
+          "latest_check_runs_count": 2,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        },
+        {
+          "head_branch": "test-test",
+          "head_sha": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "status": "queued",
+          "before": "29f5936b763a27b8703699e18f4d0f4a0e37ddbf",
+          "after": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6",
+          "pull_requests": [],
+          "app": {
+            "slug": "dependabot",
+            "owner": {
+              "login": "github",
+              "type": "Organization"
+            },
+            "name": "Dependabot",
+            "permissions": {
+              "checks": "write",
+              "contents": "write",
+              "issues": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "write",
+              "statuses": "read",
+              "workflows": "write"
+            },
+            "events": [
+              "check_suite",
+              "issues",
+              "issue_comment",
+              "label",
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment",
+              "repository"
+            ]
+          },
+          "latest_check_runs_count": 0,
+          "head_commit": {
+            "tree_id": "51fcf48eb13bbff985dc6662d6043e03271ac1a4",
+            "message": "feat: test2",
+            "timestamp": "2020-05-28T08:47:11Z",
+            "author": {
+              "name": "Oguz"
+            },
+            "committer": {
+              "name": "Oguz"
+            }
+          },
+          "repository": {
+            "name": "merge-me-test",
+            "full_name": "Merge-Me-Test-Organisation/merge-me-test",
+            "owner": {
+              "login": "Merge-Me-Test-Organisation",
+              "type": "Organization"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/review_teams_with_rejects/039_repos.getContents.json
+++ b/test/fixtures/review_teams_with_rejects/039_repos.getContents.json
@@ -1,0 +1,20 @@
+{
+  "name": "repos.getContents",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "path": ".github/merge-me.yml"
+  },
+  "result": {
+    "data": {
+      "name": "merge-me.yml",
+      "path": ".github/merge-me.yml",
+      "sha": "4c061e4bc0fff3dd9ffce937c320fdead239b564",
+      "size": 28,
+      "type": "file",
+      "content": "cmV2aWV3VGVhbXM6Ci0gZGV2Ci0gZGVzaWduCg==\n",
+      "encoding": "base64"
+    }
+  }
+}

--- a/test/fixtures/review_teams_with_rejects/040_pullRequests.listReviews.json
+++ b/test/fixtures/review_teams_with_rejects/040_pullRequests.listReviews.json
@@ -1,0 +1,40 @@
+{
+  "name": "pullRequests.listReviews",
+  "type": "api-call",
+  "args": {
+    "owner": "Merge-Me-Test-Organisation",
+    "repo": "merge-me-test",
+    "number": 12
+  },
+  "result": {
+    "data": [
+      {
+        "user": {
+          "login": "notoguz",
+          "type": "User"
+        },
+        "state": "APPROVED",
+        "author_association": "MEMBER",
+        "commit_id": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+      },
+      {
+        "user": {
+          "login": "notoguz2",
+          "type": "User"
+        },
+        "state": "APPROVED",
+        "author_association": "MEMBER",
+        "commit_id": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+      },
+      {
+        "user": {
+          "login": "notoguz3",
+          "type": "User"
+        },
+        "state": "CHANGES_REQUESTED",
+        "author_association": "MEMBER",
+        "commit_id": "f9d55a5bff002d1e17967c5edc1fa979b9c243d6"
+      }
+    ]
+  }
+}

--- a/test/fixtures/review_teams_with_rejects/041_teams.list.json
+++ b/test/fixtures/review_teams_with_rejects/041_teams.list.json
@@ -1,0 +1,31 @@
+{
+  "name": "teams.list",
+  "type": "api-call",
+  "args": {
+    "org": "Merge-Me-Test-Organisation"
+  },
+  "result": {
+    "data": [
+      {
+        "name": "design",
+        "id": 3861523,
+        "slug": "design",
+        "privacy": "closed",
+        "permission": "pull"
+      },
+      {
+        "name": "dev",
+        "id": 3861522,
+        "slug": "dev",
+        "privacy": "closed",
+        "permission": "pull"
+      },
+      {
+        "name": "testteam123",
+        "slug": "testteam123",
+        "privacy": "closed",
+        "permission": "pull"
+      }
+    ]
+  }
+}

--- a/test/fixtures/review_teams_with_rejects/042_teams.listMembers.json
+++ b/test/fixtures/review_teams_with_rejects/042_teams.listMembers.json
@@ -1,0 +1,20 @@
+{
+  "name": "teams.listMembers",
+  "type": "api-call",
+  "args": {
+    "org": "Merge-Me-Test-Organisation",
+    "team_id": 3861523
+  },
+  "result": {
+    "data": [
+      {
+        "login": "oguzeroglu",
+        "type": "User"
+      },
+      {
+        "login": "notoguz2",
+        "type": "User"
+      }
+    ]
+  }
+}

--- a/test/fixtures/review_teams_with_rejects/043_teams.listMembers.json
+++ b/test/fixtures/review_teams_with_rejects/043_teams.listMembers.json
@@ -1,0 +1,24 @@
+{
+  "name": "teams.listMembers",
+  "type": "api-call",
+  "args": {
+    "org": "Merge-Me-Test-Organisation",
+    "team_id": 3861522
+  },
+  "result": {
+    "data": [
+      {
+        "login": "oguzeroglu",
+        "type": "User"
+      },
+      {
+        "login": "notoguz",
+        "type": "User"
+      },
+      {
+        "login": "notoguz3",
+        "type": "User"
+      }
+    ]
+  }
+}

--- a/test/fixtures/with_minapprovals_config/002_pull_request.synchronize.json
+++ b/test/fixtures/with_minapprovals_config/002_pull_request.synchronize.json
@@ -1,0 +1,106 @@
+{
+  "name": "pull_request.synchronize",
+  "type": "event",
+  "payload": {
+    "action": "synchronize",
+    "number": 1,
+    "pull_request": {
+      "number": 1,
+      "state": "open",
+      "title": "Update test.txt",
+      "user": {
+        "login": "waltaaa",
+        "type": "User"
+      },
+      "merge_commit_sha": "ddf7426cc44392a09f9cbd80552ecf842ab76ca6",
+      "assignees": [],
+      "requested_reviewers": [
+        {
+          "login": "nikku",
+          "type": "User"
+        }
+      ],
+      "requested_teams": [],
+      "labels": [],
+      "head": {
+        "label": "nikku:waltaaa-patch-1",
+        "ref": "waltaaa-patch-1",
+        "sha": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+        "user": {
+          "login": "nikku",
+          "type": "User"
+        },
+        "repo": {
+          "name": "testtest-checks",
+          "full_name": "nikku/testtest-checks",
+          "owner": {
+            "login": "nikku",
+            "type": "User"
+          },
+          "size": 0,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 1,
+          "forks": 0,
+          "open_issues": 1,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "base": {
+        "label": "nikku:master",
+        "ref": "master",
+        "sha": "ee640dc5872b064a1b48c24f823099fe6882d69e",
+        "user": {
+          "login": "nikku",
+          "type": "User"
+        },
+        "repo": {
+          "name": "testtest-checks",
+          "full_name": "nikku/testtest-checks",
+          "owner": {
+            "login": "nikku",
+            "type": "User"
+          },
+          "size": 0,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 1,
+          "forks": 0,
+          "open_issues": 1,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "author_association": "COLLABORATOR",
+      "mergeable_state": "unknown",
+      "comments": 0,
+      "review_comments": 0,
+      "commits": 2,
+      "additions": 2,
+      "deletions": 0,
+      "changed_files": 1
+    },
+    "before": "3831781b1c99d53a22dff46de4da83c4640916da",
+    "after": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+    "repository": {
+      "name": "testtest-checks",
+      "full_name": "nikku/testtest-checks",
+      "owner": {
+        "login": "nikku",
+        "type": "User"
+      },
+      "size": 0,
+      "stargazers_count": 0,
+      "watchers_count": 0,
+      "forks_count": 0,
+      "open_issues_count": 1,
+      "forks": 0,
+      "open_issues": 1,
+      "watchers": 0,
+      "default_branch": "master"
+    }
+  }
+}

--- a/test/fixtures/with_minapprovals_config/003_repos.getBranchProtection.json
+++ b/test/fixtures/with_minapprovals_config/003_repos.getBranchProtection.json
@@ -1,0 +1,14 @@
+{
+  "name": "repos.getBranchProtection",
+  "type": "api-call",
+  "args": {
+    "owner": "nikku",
+    "repo": "testtest-checks",
+    "branch": "master"
+  },
+  "result": {
+    "error": {
+      "status": 404
+    }
+  }
+}

--- a/test/fixtures/with_minapprovals_config/004_repos.getCombinedStatusForRef.json
+++ b/test/fixtures/with_minapprovals_config/004_repos.getCombinedStatusForRef.json
@@ -1,0 +1,25 @@
+{
+  "name": "repos.getCombinedStatusForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "nikku",
+    "repo": "testtest-checks",
+    "ref": "ca7142df376bebb6edcc0c156ca6897d39f468e2"
+  },
+  "result": {
+    "data": {
+      "state": "pending",
+      "statuses": [],
+      "sha": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+      "total_count": 0,
+      "repository": {
+        "name": "testtest-checks",
+        "full_name": "nikku/testtest-checks",
+        "owner": {
+          "login": "nikku",
+          "type": "User"
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/with_minapprovals_config/005_checks.listSuitesForRef.json
+++ b/test/fixtures/with_minapprovals_config/005_checks.listSuitesForRef.json
@@ -1,0 +1,69 @@
+{
+  "name": "checks.listSuitesForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "nikku",
+    "repo": "testtest-checks",
+    "ref": "ca7142df376bebb6edcc0c156ca6897d39f468e2"
+  },
+  "result": {
+    "data": {
+      "total_count": 1,
+      "check_suites": [
+        {
+          "head_branch": "waltaaa-patch-1",
+          "head_sha": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+          "status": "queued",
+          "before": "3831781b1c99d53a22dff46de4da83c4640916da",
+          "after": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+          "pull_requests": [
+            {
+              "number": 1,
+              "head": {
+                "ref": "waltaaa-patch-1",
+                "sha": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+                "repo": {
+                  "name": "testtest-checks"
+                }
+              },
+              "base": {
+                "ref": "master",
+                "sha": "ee640dc5872b064a1b48c24f823099fe6882d69e",
+                "repo": {
+                  "name": "testtest-checks"
+                }
+              }
+            }
+          ],
+          "app": {
+            "owner": {
+              "login": "travis-ci",
+              "type": "Organization"
+            },
+            "name": "Travis CI"
+          },
+          "latest_check_runs_count": 1,
+          "head_commit": {
+            "tree_id": "125410ff8369edabdecd887abfe10b746beaa687",
+            "message": "Update test.txt",
+            "timestamp": "2018-11-28T21:20:07Z",
+            "author": {
+              "name": "waltaaa"
+            },
+            "committer": {
+              "name": "GitHub"
+            }
+          },
+          "repository": {
+            "name": "testtest-checks",
+            "full_name": "nikku/testtest-checks",
+            "owner": {
+              "login": "nikku",
+              "type": "User"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/with_minapprovals_config/006_check_suite.completed.json
+++ b/test/fixtures/with_minapprovals_config/006_check_suite.completed.json
@@ -1,0 +1,70 @@
+{
+  "name": "check_suite.completed",
+  "type": "event",
+  "payload": {
+    "action": "completed",
+    "check_suite": {
+      "head_branch": "waltaaa-patch-1",
+      "head_sha": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+      "status": "completed",
+      "conclusion": "success",
+      "before": "3831781b1c99d53a22dff46de4da83c4640916da",
+      "after": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+      "pull_requests": [
+        {
+          "number": 1,
+          "head": {
+            "ref": "waltaaa-patch-1",
+            "sha": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+            "repo": {
+              "name": "testtest-checks"
+            }
+          },
+          "base": {
+            "ref": "master",
+            "sha": "ee640dc5872b064a1b48c24f823099fe6882d69e",
+            "repo": {
+              "name": "testtest-checks"
+            }
+          }
+        }
+      ],
+      "app": {
+        "owner": {
+          "login": "travis-ci",
+          "type": "Organization"
+        },
+        "name": "Travis CI"
+      },
+      "latest_check_runs_count": 2,
+      "head_commit": {
+        "tree_id": "125410ff8369edabdecd887abfe10b746beaa687",
+        "message": "Update test.txt",
+        "timestamp": "2018-11-28T21:20:07Z",
+        "author": {
+          "name": "waltaaa"
+        },
+        "committer": {
+          "name": "GitHub"
+        }
+      }
+    },
+    "repository": {
+      "name": "testtest-checks",
+      "full_name": "nikku/testtest-checks",
+      "owner": {
+        "login": "nikku",
+        "type": "User"
+      },
+      "size": 0,
+      "stargazers_count": 0,
+      "watchers_count": 0,
+      "forks_count": 0,
+      "open_issues_count": 1,
+      "forks": 0,
+      "open_issues": 1,
+      "watchers": 0,
+      "default_branch": "master"
+    }
+  }
+}

--- a/test/fixtures/with_minapprovals_config/007_repos.getBranchProtection.json
+++ b/test/fixtures/with_minapprovals_config/007_repos.getBranchProtection.json
@@ -1,0 +1,14 @@
+{
+  "name": "repos.getBranchProtection",
+  "type": "api-call",
+  "args": {
+    "owner": "nikku",
+    "repo": "testtest-checks",
+    "branch": "master"
+  },
+  "result": {
+    "error": {
+      "status": 404
+    }
+  }
+}

--- a/test/fixtures/with_minapprovals_config/008_repos.getCombinedStatusForRef.json
+++ b/test/fixtures/with_minapprovals_config/008_repos.getCombinedStatusForRef.json
@@ -1,0 +1,25 @@
+{
+  "name": "repos.getCombinedStatusForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "nikku",
+    "repo": "testtest-checks",
+    "ref": "ca7142df376bebb6edcc0c156ca6897d39f468e2"
+  },
+  "result": {
+    "data": {
+      "state": "pending",
+      "statuses": [],
+      "sha": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+      "total_count": 0,
+      "repository": {
+        "name": "testtest-checks",
+        "full_name": "nikku/testtest-checks",
+        "owner": {
+          "login": "nikku",
+          "type": "User"
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/with_minapprovals_config/009_checks.listSuitesForRef.json
+++ b/test/fixtures/with_minapprovals_config/009_checks.listSuitesForRef.json
@@ -1,0 +1,70 @@
+{
+  "name": "checks.listSuitesForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "nikku",
+    "repo": "testtest-checks",
+    "ref": "ca7142df376bebb6edcc0c156ca6897d39f468e2"
+  },
+  "result": {
+    "data": {
+      "total_count": 1,
+      "check_suites": [
+        {
+          "head_branch": "waltaaa-patch-1",
+          "head_sha": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+          "status": "completed",
+          "conclusion": "success",
+          "before": "3831781b1c99d53a22dff46de4da83c4640916da",
+          "after": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+          "pull_requests": [
+            {
+              "number": 1,
+              "head": {
+                "ref": "waltaaa-patch-1",
+                "sha": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+                "repo": {
+                  "name": "testtest-checks"
+                }
+              },
+              "base": {
+                "ref": "master",
+                "sha": "ee640dc5872b064a1b48c24f823099fe6882d69e",
+                "repo": {
+                  "name": "testtest-checks"
+                }
+              }
+            }
+          ],
+          "app": {
+            "owner": {
+              "login": "travis-ci",
+              "type": "Organization"
+            },
+            "name": "Travis CI"
+          },
+          "latest_check_runs_count": 2,
+          "head_commit": {
+            "tree_id": "125410ff8369edabdecd887abfe10b746beaa687",
+            "message": "Update test.txt",
+            "timestamp": "2018-11-28T21:20:07Z",
+            "author": {
+              "name": "waltaaa"
+            },
+            "committer": {
+              "name": "GitHub"
+            }
+          },
+          "repository": {
+            "name": "testtest-checks",
+            "full_name": "nikku/testtest-checks",
+            "owner": {
+              "login": "nikku",
+              "type": "User"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/with_minapprovals_config/010_repos.getContents.json
+++ b/test/fixtures/with_minapprovals_config/010_repos.getContents.json
@@ -1,0 +1,14 @@
+{
+  "name": "repos.getContents",
+  "type": "api-call",
+  "args": {
+    "owner": "nikku",
+    "repo": "testtest-checks",
+    "path": ".github/merge-me.yml"
+  },
+  "result": {
+    "data": {
+      "content": "bWluQXBwcm92YWxzOiAy"
+    }
+  }
+}

--- a/test/fixtures/with_minapprovals_config/011_pullRequests.listReviews.json
+++ b/test/fixtures/with_minapprovals_config/011_pullRequests.listReviews.json
@@ -1,0 +1,12 @@
+{
+  "name": "pullRequests.listReviews",
+  "type": "api-call",
+  "args": {
+    "owner": "nikku",
+    "repo": "testtest-checks",
+    "number": 1
+  },
+  "result": {
+    "data": []
+  }
+}

--- a/test/fixtures/with_minapprovals_config/012_pull_request_review.submitted.json
+++ b/test/fixtures/with_minapprovals_config/012_pull_request_review.submitted.json
@@ -1,0 +1,100 @@
+{
+  "name": "pull_request_review.submitted",
+  "type": "event",
+  "payload": {
+    "action": "submitted",
+    "review": {
+      "user": {
+        "login": "nikku",
+        "type": "User"
+      },
+      "commit_id": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+      "state": "approved",
+      "author_association": "OWNER"
+    },
+    "pull_request": {
+      "number": 1,
+      "state": "open",
+      "title": "Update test.txt",
+      "user": {
+        "login": "waltaaa",
+        "type": "User"
+      },
+      "merge_commit_sha": "a4c53fa7a55e33d6e945d89a180d5226adc08d6e",
+      "assignees": [],
+      "requested_reviewers": [],
+      "requested_teams": [],
+      "labels": [],
+      "head": {
+        "label": "nikku:waltaaa-patch-1",
+        "ref": "waltaaa-patch-1",
+        "sha": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+        "user": {
+          "login": "nikku",
+          "type": "User"
+        },
+        "repo": {
+          "name": "testtest-checks",
+          "full_name": "nikku/testtest-checks",
+          "owner": {
+            "login": "nikku",
+            "type": "User"
+          },
+          "size": 0,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 1,
+          "forks": 0,
+          "open_issues": 1,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "base": {
+        "label": "nikku:master",
+        "ref": "master",
+        "sha": "ee640dc5872b064a1b48c24f823099fe6882d69e",
+        "user": {
+          "login": "nikku",
+          "type": "User"
+        },
+        "repo": {
+          "name": "testtest-checks",
+          "full_name": "nikku/testtest-checks",
+          "owner": {
+            "login": "nikku",
+            "type": "User"
+          },
+          "size": 0,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 1,
+          "forks": 0,
+          "open_issues": 1,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "author_association": "COLLABORATOR"
+    },
+    "repository": {
+      "name": "testtest-checks",
+      "full_name": "nikku/testtest-checks",
+      "owner": {
+        "login": "nikku",
+        "type": "User"
+      },
+      "size": 0,
+      "stargazers_count": 0,
+      "watchers_count": 0,
+      "forks_count": 0,
+      "open_issues_count": 1,
+      "forks": 0,
+      "open_issues": 1,
+      "watchers": 0,
+      "default_branch": "master"
+    }
+  }
+}

--- a/test/fixtures/with_minapprovals_config/013_repos.getBranchProtection.json
+++ b/test/fixtures/with_minapprovals_config/013_repos.getBranchProtection.json
@@ -1,0 +1,14 @@
+{
+  "name": "repos.getBranchProtection",
+  "type": "api-call",
+  "args": {
+    "owner": "nikku",
+    "repo": "testtest-checks",
+    "branch": "master"
+  },
+  "result": {
+    "error": {
+      "status": 404
+    }
+  }
+}

--- a/test/fixtures/with_minapprovals_config/014_repos.getCombinedStatusForRef.json
+++ b/test/fixtures/with_minapprovals_config/014_repos.getCombinedStatusForRef.json
@@ -1,0 +1,25 @@
+{
+  "name": "repos.getCombinedStatusForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "nikku",
+    "repo": "testtest-checks",
+    "ref": "ca7142df376bebb6edcc0c156ca6897d39f468e2"
+  },
+  "result": {
+    "data": {
+      "state": "pending",
+      "statuses": [],
+      "sha": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+      "total_count": 0,
+      "repository": {
+        "name": "testtest-checks",
+        "full_name": "nikku/testtest-checks",
+        "owner": {
+          "login": "nikku",
+          "type": "User"
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/with_minapprovals_config/015_checks.listSuitesForRef.json
+++ b/test/fixtures/with_minapprovals_config/015_checks.listSuitesForRef.json
@@ -1,0 +1,70 @@
+{
+  "name": "checks.listSuitesForRef",
+  "type": "api-call",
+  "args": {
+    "owner": "nikku",
+    "repo": "testtest-checks",
+    "ref": "ca7142df376bebb6edcc0c156ca6897d39f468e2"
+  },
+  "result": {
+    "data": {
+      "total_count": 1,
+      "check_suites": [
+        {
+          "head_branch": "waltaaa-patch-1",
+          "head_sha": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+          "status": "completed",
+          "conclusion": "success",
+          "before": "3831781b1c99d53a22dff46de4da83c4640916da",
+          "after": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+          "pull_requests": [
+            {
+              "number": 1,
+              "head": {
+                "ref": "waltaaa-patch-1",
+                "sha": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+                "repo": {
+                  "name": "testtest-checks"
+                }
+              },
+              "base": {
+                "ref": "master",
+                "sha": "ee640dc5872b064a1b48c24f823099fe6882d69e",
+                "repo": {
+                  "name": "testtest-checks"
+                }
+              }
+            }
+          ],
+          "app": {
+            "owner": {
+              "login": "travis-ci",
+              "type": "Organization"
+            },
+            "name": "Travis CI"
+          },
+          "latest_check_runs_count": 2,
+          "head_commit": {
+            "tree_id": "125410ff8369edabdecd887abfe10b746beaa687",
+            "message": "Update test.txt",
+            "timestamp": "2018-11-28T21:20:07Z",
+            "author": {
+              "name": "waltaaa"
+            },
+            "committer": {
+              "name": "GitHub"
+            }
+          },
+          "repository": {
+            "name": "testtest-checks",
+            "full_name": "nikku/testtest-checks",
+            "owner": {
+              "login": "nikku",
+              "type": "User"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/with_minapprovals_config/016_repos.getContents.json
+++ b/test/fixtures/with_minapprovals_config/016_repos.getContents.json
@@ -1,0 +1,14 @@
+{
+  "name": "repos.getContents",
+  "type": "api-call",
+  "args": {
+    "owner": "nikku",
+    "repo": "testtest-checks",
+    "path": ".github/merge-me.yml"
+  },
+  "result": {
+    "data": {
+      "content": "bWluQXBwcm92YWxzOiAy"
+    }
+  }
+}

--- a/test/fixtures/with_minapprovals_config/017_pullRequests.listReviews.json
+++ b/test/fixtures/with_minapprovals_config/017_pullRequests.listReviews.json
@@ -1,0 +1,31 @@
+{
+  "name": "pullRequests.listReviews",
+  "type": "api-call",
+  "args": {
+    "owner": "nikku",
+    "repo": "testtest-checks",
+    "number": 1
+  },
+  "result": {
+    "data": [
+      {
+        "user": {
+          "login": "nikku",
+          "type": "User"
+        },
+        "state": "APPROVED",
+        "author_association": "OWNER",
+        "commit_id": "ca7142df376bebb6edcc0c156ca6897d39f468e2"
+      },
+      {
+        "user": {
+          "login": "oguzeroglu",
+          "type": "User"
+        },
+        "state": "APPROVED",
+        "author_association": "MEMBER",
+        "commit_id": "ca7142df376bebb6edcc0c156ca6897d39f468e2"
+      }
+    ]
+  }
+}

--- a/test/fixtures/with_minapprovals_config/018_pullRequests.merge.json
+++ b/test/fixtures/with_minapprovals_config/018_pullRequests.merge.json
@@ -1,0 +1,17 @@
+{
+  "name": "pullRequests.merge",
+  "type": "api-call",
+  "args": {
+    "owner": "nikku",
+    "repo": "testtest-checks",
+    "number": 1,
+    "sha": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+    "merge_method": "rebase"
+  },
+  "result": {
+    "data": {
+      "sha": "18bf62ff9ce3b89190dd4b15ddcfcd77dd4b4fef",
+      "message": "Pull Request successfully merged"
+    }
+  }
+}

--- a/test/fixtures/with_minapprovals_config/019_pull_request.closed.json
+++ b/test/fixtures/with_minapprovals_config/019_pull_request.closed.json
@@ -1,0 +1,103 @@
+{
+  "name": "pull_request.closed",
+  "type": "event",
+  "payload": {
+    "action": "closed",
+    "number": 1,
+    "pull_request": {
+      "number": 1,
+      "state": "closed",
+      "title": "Update test.txt",
+      "user": {
+        "login": "waltaaa",
+        "type": "User"
+      },
+      "merge_commit_sha": "18bf62ff9ce3b89190dd4b15ddcfcd77dd4b4fef",
+      "assignees": [],
+      "requested_reviewers": [],
+      "requested_teams": [],
+      "labels": [],
+      "head": {
+        "label": "nikku:waltaaa-patch-1",
+        "ref": "waltaaa-patch-1",
+        "sha": "ca7142df376bebb6edcc0c156ca6897d39f468e2",
+        "user": {
+          "login": "nikku",
+          "type": "User"
+        },
+        "repo": {
+          "name": "testtest-checks",
+          "full_name": "nikku/testtest-checks",
+          "owner": {
+            "login": "nikku",
+            "type": "User"
+          },
+          "size": 0,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 0,
+          "forks": 0,
+          "open_issues": 0,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "base": {
+        "label": "nikku:master",
+        "ref": "master",
+        "sha": "ee640dc5872b064a1b48c24f823099fe6882d69e",
+        "user": {
+          "login": "nikku",
+          "type": "User"
+        },
+        "repo": {
+          "name": "testtest-checks",
+          "full_name": "nikku/testtest-checks",
+          "owner": {
+            "login": "nikku",
+            "type": "User"
+          },
+          "size": 0,
+          "stargazers_count": 0,
+          "watchers_count": 0,
+          "forks_count": 0,
+          "open_issues_count": 0,
+          "forks": 0,
+          "open_issues": 0,
+          "watchers": 0,
+          "default_branch": "master"
+        }
+      },
+      "author_association": "COLLABORATOR",
+      "mergeable_state": "unknown",
+      "merged_by": {
+        "login": "merge-me-test[bot]",
+        "type": "Bot"
+      },
+      "comments": 0,
+      "review_comments": 0,
+      "commits": 2,
+      "additions": 2,
+      "deletions": 0,
+      "changed_files": 1
+    },
+    "repository": {
+      "name": "testtest-checks",
+      "full_name": "nikku/testtest-checks",
+      "owner": {
+        "login": "nikku",
+        "type": "User"
+      },
+      "size": 0,
+      "stargazers_count": 0,
+      "watchers_count": 0,
+      "forks_count": 0,
+      "open_issues_count": 0,
+      "forks": 0,
+      "open_issues": 0,
+      "watchers": 0,
+      "default_branch": "master"
+    }
+  }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -64,6 +64,24 @@ describe('bot', function() {
 
   });
 
+
+  describe('config', function() {
+
+    it('should consider minApprovals config', async function() {
+
+      // in this test following YML configuration is returned within
+      // repos.getContents.json files (encoded in Base64):
+      //    minApprovals: 2
+      //
+      // listReviews API call returns 2 approved reviews.
+
+      // given
+      const recording = loadRecording('with_minapprovals_config');
+
+      // then
+      await recording.replay();
+    });
+  });
 });
 
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -85,14 +85,14 @@ describe('bot', function() {
 
     describe('team reviews', function() {
 
-      it('should consider reviewTeams config', async function() {
+      // for team reviews tests, following YML configuration is returned within
+      // repos.getContents.json files (encided in Base64):
+      //
+      // reviewTeams:
+      // - dev
+      // - design
 
-        // in this test following YML configuration is returned within
-        // repos.getContents.json files (encided in Base64):
-        //
-        // reviewTeams:
-        // - dev
-        // - design
+      it('should consider reviewTeams config', async function() {
 
         // Scenario:
         // One person from dev team approves.
@@ -101,6 +101,29 @@ describe('bot', function() {
 
         // given
         const recording = loadRecording('review_teams_simple');
+
+        // then
+        await recording.replay();
+      });
+
+
+      it('should correctly handle people with multiple teams', async function() {
+
+        // Scenario:
+        //
+        // dev: a, b
+        // design: a, b, c
+        //
+        // [a] opens a pull request
+        // [c] approves
+        // [b] approves
+        // PR gets merged.
+        //
+        // Since dev is configured before design inside the YAML file,
+        // the approval of [b] is counted as dev approval rather than design approval.
+
+        // given
+        const recording = loadRecording('review_teams_multi_team');
 
         // then
         await recording.replay();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -128,6 +128,25 @@ describe('bot', function() {
         // then
         await recording.replay();
       });
+
+
+      it('should not merge unless there are approvals from each configured team', async function() {
+
+        // Scenario:
+        //
+        // dev: a, b, c
+        // design: d
+        //
+        // a opens a pull request.
+        // a asks for a review from b, c and d.
+        // b and c approves -> no merge. (design approval is missing).
+
+        // given
+        const recording = loadRecording('review_teams_approval_missing');
+
+        // then
+        await recording.replay();
+      });
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -147,6 +147,25 @@ describe('bot', function() {
         // then
         await recording.replay();
       });
+
+
+      it('should not merge is there are rejected reviews', async function() {
+
+        // Scenario
+        //
+        // design: a, b
+        // dev: c, d
+        //
+        // PR is opened. Review is requested from a, b and c.
+        //
+        // b and c approves, however a rejects -> No merge.
+
+        // given
+        const recording = loadRecording('review_teams_with_rejects');
+
+        // then
+        await recording.replay();
+      });
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -81,6 +81,31 @@ describe('bot', function() {
       // then
       await recording.replay();
     });
+
+
+    describe('team reviews', function() {
+
+      it('should consider reviewTeams config', async function() {
+
+        // in this test following YML configuration is returned within
+        // repos.getContents.json files (encided in Base64):
+        //
+        // reviewTeams:
+        // - dev
+        // - design
+
+        // Scenario:
+        // One person from dev team approves.
+        // One person from design team approves.
+        // PR is merged.
+
+        // given
+        const recording = loadRecording('review_teams_simple');
+
+        // then
+        await recording.replay();
+      });
+    });
   });
 });
 


### PR DESCRIPTION
This PR integrates teams into merge-me bot.

Teams can be configured via `merge-me.yml`. An example configuration would be:

```yaml
reviewTeams:
   - design
   - dev
```

Given that configuration the bot will figure out based on requested and actual reviewers what the effective list of teams to review is. __This means that it will only require a review from a given team, if it is included via a mentioned reviewer.__

Per team the existing `minApprovals` is taken into account.